### PR TITLE
Set featured image to first image if no position is provided and remove placeholder.

### DIFF
--- a/api/class-wc-rest-dev-product-variations-controller.php
+++ b/api/class-wc-rest-dev-product-variations-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products/<product_id>/variations endpoints.
  *
- * @author   WooThemes
+ * @author   Automattic
  * @category API
  * @package  WooCommerce/API
  * @since    3.0.0
@@ -27,5 +27,45 @@ class WC_REST_Dev_Product_Variations_Controller extends WC_REST_Product_Variatio
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get the image for a product variation.
+	 *
+	 * @param WC_Product_Variation $variation Variation
+	 * @return array
+	 */
+	protected function get_images( $variation ) {
+		if ( has_post_thumbnail( $variation->get_id() ) ) {
+			$attachment_id = $variation->get_image_id();
+		} else {
+			$attachment_id = current( $variation->get_gallery_image_ids() );
+		}
+
+		$attachment_post = get_post( $attachment_id );
+		if ( is_null( $attachment_post ) ) {
+			$image = array();
+		}
+
+		$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+		if ( ! is_array( $attachment ) ) {
+			$image = array();
+		}
+
+		if ( ! isset ( $image ) ) {
+			$image = array(
+				'id'                => (int) $attachment_id,
+				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
+				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
+				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
+				'date_modified_gmt' => wc_rest_prepare_date_response( strtotime( $attachment_post->post_modified_gmt ) ),
+				'src'               => current( $attachment ),
+				'name'              => get_the_title( $attachment_id ),
+				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+				'position'          => (int) $position,
+			);
+		}
+
+		return array( $image );
+	}
 
 }

--- a/api/class-wc-rest-dev-product-variations-controller.php
+++ b/api/class-wc-rest-dev-product-variations-controller.php
@@ -35,12 +35,7 @@ class WC_REST_Dev_Product_Variations_Controller extends WC_REST_Product_Variatio
 	 * @return array
 	 */
 	protected function get_images( $variation ) {
-		if ( has_post_thumbnail( $variation->get_id() ) ) {
-			$attachment_id = $variation->get_image_id();
-		} else {
-			$attachment_id = current( $variation->get_gallery_image_ids() );
-		}
-
+		$attachment_id = $variation->get_image_id();
 		$attachment_post = get_post( $attachment_id );
 		if ( is_null( $attachment_post ) ) {
 			$image = array();
@@ -61,11 +56,365 @@ class WC_REST_Dev_Product_Variations_Controller extends WC_REST_Product_Variatio
 				'src'               => current( $attachment ),
 				'name'              => get_the_title( $attachment_id ),
 				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
-				'position'          => (int) $position,
 			);
 		}
 
 		return array( $image );
+	}
+
+	/**
+	 * Get the Variation's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$schema         = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created' => array(
+					'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified' => array(
+					'description' => __( "The date the variation was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'Variation description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'permalink' => array(
+					'description' => __( 'Variation URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'sku' => array(
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price' => array(
+					'description' => __( 'Current variation price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'regular_price' => array(
+					'description' => __( 'Variation regular price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sale_price' => array(
+					'description' => __( 'Variation sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from' => array(
+					'description' => __( "Start date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from_gmt' => array(
+					'description' => __( 'Start date of sale price, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to' => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to_gmt' => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'on_sale' => array(
+					'description' => __( 'Shows if the variation is on sale.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'visible' => array(
+					'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'purchasable' => array(
+					'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'virtual' => array(
+					'description' => __( 'If the variation is virtual.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloadable' => array(
+					'description' => __( 'If the variation is downloadable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloads' => array(
+					'description' => __( 'List of downloadable files.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'download_limit' => array(
+					'description' => __( 'Number of times downloadable files can be downloaded after purchase.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'download_expiry' => array(
+					'description' => __( 'Number of days until access to downloadable files expires.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_status' => array(
+					'description' => __( 'Tax status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'taxable',
+					'enum'        => array( 'taxable', 'shipping', 'none' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_class' => array(
+					'description' => __( 'Tax class.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'manage_stock' => array(
+					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'stock_quantity' => array(
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'in_stock' => array(
+					'description' => __( 'Controls whether or not the variation is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders' => array(
+					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'no',
+					'enum'        => array( 'no', 'notify', 'yes' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders_allowed' => array(
+					'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'backordered' => array(
+					'description' => __( 'Shows if the variation is on backordered.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'weight' => array(
+					/* translators: %s: weight unit */
+					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'dimensions' => array(
+					'description' => __( 'Variation dimensions.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'length' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'width' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'height' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping_class' => array(
+					'description' => __( 'Shipping class slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'shipping_class_id' => array(
+					'description' => __( 'Shipping class ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'image' => array(
+					'description' => __( 'Variation image data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'Image ID.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'date_created' => array(
+							'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_created_gmt' => array(
+							'description' => __( 'The date the image was created, as GMT.', 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_modified' => array(
+							'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_modified_gmt' => array(
+							'description' => __( 'The date the image was last modified, as GMT.', 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'src' => array(
+							'description' => __( 'Image URL.', 'woocommerce' ),
+							'type'        => 'string',
+							'format'      => 'uri',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'name' => array(
+							'description' => __( 'Image name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'alt' => array(
+							'description' => __( 'Image alternative text.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'attributes' => array(
+					'description' => __( 'List of attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'menu_order' => array(
+					'description' => __( 'Menu order, used to custom sort products.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'meta_data' => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
 	}
 
 }

--- a/api/class-wc-rest-dev-products-controller.php
+++ b/api/class-wc-rest-dev-products-controller.php
@@ -47,7 +47,7 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
 
 		// Build image data.
-		foreach ( $attachment_ids as $position => $attachment_id ) {
+		foreach ( $attachment_ids as $attachment_id ) {
 			$attachment_post = get_post( $attachment_id );
 			if ( is_null( $attachment_post ) ) {
 				continue;
@@ -67,7 +67,6 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 				'src'               => current( $attachment ),
 				'name'              => get_the_title( $attachment_id ),
 				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
-				'position'          => (int) $position,
 			);
 		}
 
@@ -86,7 +85,7 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 		if ( is_array( $images ) ) {
 			$gallery = array();
 
-			foreach ( $images as $image ) {
+			foreach ( $images as $index => $image ) {
 				$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
 				if ( 0 === $attachment_id && isset( $image['src'] ) ) {
@@ -109,9 +108,7 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 
 				$featured_image = $product->get_image_id();
 
-				if ( isset( $image['position'] ) && 0 === absint( $image['position'] ) ) {
-					$product->set_image_id( $attachment_id );
-				} elseif( empty( $image['position'] ) && empty( $featured_image ) ) {
+				if ( 0 === $index ) {
 					$product->set_image_id( $attachment_id );
 				} else {
 					$gallery[] = $attachment_id;
@@ -135,6 +132,620 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 		}
 
 		return $product;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$schema         = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Product name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'slug' => array(
+					'description' => __( 'Product slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'permalink' => array(
+					'description' => __( 'Product URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created' => array(
+					'description' => __( "The date the product was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt' => array(
+					'description' => __( "The date the product was created, as GMT.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified' => array(
+					'description' => __( "The date the product was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified_gmt' => array(
+					'description' => __( "The date the product was last modified, as GMT.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'type' => array(
+					'description' => __( 'Product type.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'simple',
+					'enum'        => array_keys( wc_get_product_types() ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'status' => array(
+					'description' => __( 'Product status (post status).', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'publish',
+					'enum'        => array_keys( get_post_statuses() ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'featured' => array(
+					'description' => __( 'Featured product.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'catalog_visibility' => array(
+					'description' => __( 'Catalog visibility.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'visible',
+					'enum'        => array( 'visible', 'catalog', 'search', 'hidden' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description' => array(
+					'description' => __( 'Product description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'short_description' => array(
+					'description' => __( 'Product short description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sku' => array(
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price' => array(
+					'description' => __( 'Current product price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'regular_price' => array(
+					'description' => __( 'Product regular price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sale_price' => array(
+					'description' => __( 'Product sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from' => array(
+					'description' => __( "Start date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from_gmt' => array(
+					'description' => __( 'Start date of sale price, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to' => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to_gmt' => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price_html' => array(
+					'description' => __( 'Price formatted in HTML.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'on_sale' => array(
+					'description' => __( 'Shows if the product is on sale.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'purchasable' => array(
+					'description' => __( 'Shows if the product can be bought.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'total_sales' => array(
+					'description' => __( 'Amount of sales.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'virtual' => array(
+					'description' => __( 'If the product is virtual.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloadable' => array(
+					'description' => __( 'If the product is downloadable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloads' => array(
+					'description' => __( 'List of downloadable files.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'download_limit' => array(
+					'description' => __( 'Number of times downloadable files can be downloaded after purchase.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'download_expiry' => array(
+					'description' => __( 'Number of days until access to downloadable files expires.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'external_url' => array(
+					'description' => __( 'Product external URL. Only for external products.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'button_text' => array(
+					'description' => __( 'Product external button text. Only for external products.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_status' => array(
+					'description' => __( 'Tax status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'taxable',
+					'enum'        => array( 'taxable', 'shipping', 'none' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_class' => array(
+					'description' => __( 'Tax class.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'manage_stock' => array(
+					'description' => __( 'Stock management at product level.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'stock_quantity' => array(
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'in_stock' => array(
+					'description' => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders' => array(
+					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'no',
+					'enum'        => array( 'no', 'notify', 'yes' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders_allowed' => array(
+					'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'backordered' => array(
+					'description' => __( 'Shows if the product is on backordered.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'sold_individually' => array(
+					'description' => __( 'Allow one item to be bought in a single order.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'weight' => array(
+					/* translators: %s: weight unit */
+					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'dimensions' => array(
+					'description' => __( 'Product dimensions.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'length' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'width' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'height' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping_required' => array(
+					'description' => __( 'Shows if the product need to be shipped.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'shipping_taxable' => array(
+					'description' => __( 'Shows whether or not the product shipping is taxable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'shipping_class' => array(
+					'description' => __( 'Shipping class slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'shipping_class_id' => array(
+					'description' => __( 'Shipping class ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'reviews_allowed' => array(
+					'description' => __( 'Allow reviews.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'average_rating' => array(
+					'description' => __( 'Reviews average rating.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'rating_count' => array(
+					'description' => __( 'Amount of reviews that the product have.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'related_ids' => array(
+					'description' => __( 'List of related products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type'    => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'upsell_ids' => array(
+					'description' => __( 'List of up-sell products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type'    => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'cross_sell_ids' => array(
+					'description' => __( 'List of cross-sell products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type'    => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'parent_id' => array(
+					'description' => __( 'Product parent ID.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'purchase_note' => array(
+					'description' => __( 'Optional note to send the customer after purchase.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'categories' => array(
+					'description' => __( 'List of categories.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Category ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Category name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Category slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+				'tags' => array(
+					'description' => __( 'List of tags.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Tag ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Tag name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Tag slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+				'images' => array(
+					'description' => __( 'List of images.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Image ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'date_created' => array(
+								'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_created_gmt' => array(
+								'description' => __( "The date the image was created, as GMT.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified' => array(
+								'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified_gmt' => array(
+								'description' => __( "The date the image was last modified, as GMT.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'src' => array(
+								'description' => __( 'Image URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Image name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'alt' => array(
+								'description' => __( 'Image alternative text.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'attributes' => array(
+					'description' => __( 'List of attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'position' => array(
+								'description' => __( 'Attribute position.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'visible' => array(
+								'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'variation' => array(
+								'description' => __( 'Define if the attribute can be used as variation.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'options' => array(
+								'description' => __( 'List of available term names of the attribute.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'default_attributes' => array(
+					'description' => __( 'Defaults variation attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'variations' => array(
+					'description' => __( 'List of variations IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'    => 'integer',
+					),
+					'readonly'    => true,
+				),
+				'grouped_products' => array(
+					'description' => __( 'List of grouped products ID.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type'    => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'menu_order' => array(
+					'description' => __( 'Menu order, used to custom sort products.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'meta_data' => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
 	}
 
 }

--- a/api/class-wc-rest-dev-products-controller.php
+++ b/api/class-wc-rest-dev-products-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products endpoint.
  *
- * @author   WooThemes
+ * @author   Automattic
  * @category API
  * @package  WooCommerce/API
  * @since    2.6.0
@@ -27,5 +27,114 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get the images for a product or product variation.
+	 *
+	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 * @return array
+	 */
+	protected function get_images( $product ) {
+		$images = array();
+		$attachment_ids = array();
+
+		// Add featured image.
+		if ( has_post_thumbnail( $product->get_id() ) ) {
+			$attachment_ids[] = $product->get_image_id();
+		}
+
+		// Add gallery images.
+		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
+
+		// Build image data.
+		foreach ( $attachment_ids as $position => $attachment_id ) {
+			$attachment_post = get_post( $attachment_id );
+			if ( is_null( $attachment_post ) ) {
+				continue;
+			}
+
+			$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$images[] = array(
+				'id'                => (int) $attachment_id,
+				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
+				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
+				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
+				'date_modified_gmt' => wc_rest_prepare_date_response( strtotime( $attachment_post->post_modified_gmt ) ),
+				'src'               => current( $attachment ),
+				'name'              => get_the_title( $attachment_id ),
+				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+				'position'          => (int) $position,
+			);
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Set product images.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @param WC_Product $product Product instance.
+	 * @param array      $images  Images data.
+	 * @return WC_Product
+	 */
+	protected function set_product_images( $product, $images ) {
+		if ( is_array( $images ) ) {
+			$gallery = array();
+
+			foreach ( $images as $image ) {
+				$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+
+				if ( 0 === $attachment_id && isset( $image['src'] ) ) {
+					$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
+
+					if ( is_wp_error( $upload ) ) {
+						if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $product->get_id(), $images ) ) {
+							throw new WC_REST_Exception( 'woocommerce_product_image_upload_error', $upload->get_error_message(), 400 );
+						} else {
+							continue;
+						}
+					}
+
+					$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $product->get_id() );
+				}
+
+				if ( ! wp_attachment_is_image( $attachment_id ) ) {
+					throw new WC_REST_Exception( 'woocommerce_product_invalid_image_id', sprintf( __( '#%s is an invalid image ID.', 'woocommerce' ), $attachment_id ), 400 );
+				}
+
+				$featured_image = $product->get_image_id();
+
+				if ( isset( $image['position'] ) && 0 === absint( $image['position'] ) ) {
+					$product->set_image_id( $attachment_id );
+				} elseif( empty( $image['position'] ) && empty( $featured_image ) ) {
+					$product->set_image_id( $attachment_id );
+				} else {
+					$gallery[] = $attachment_id;
+				}
+
+				// Set the image alt if present.
+				if ( ! empty( $image['alt'] ) ) {
+					update_post_meta( $attachment_id, '_wp_attachment_image_alt', wc_clean( $image['alt'] ) );
+				}
+
+				// Set the image name if present.
+				if ( ! empty( $image['name'] ) ) {
+					wp_update_post( array( 'ID' => $attachment_id, 'post_title' => $image['name'] ) );
+				}
+			}
+
+			$product->set_gallery_image_ids( $gallery );
+		} else {
+			$product->set_image_id( '' );
+			$product->set_gallery_image_ids( array() );
+		}
+
+		return $product;
+	}
 
 }


### PR DESCRIPTION
This PR makes two updates to the product/variations endpoints:

* If no position is provided and no featured image is set, the first image is set as a product's featured image. This solves the problem I was having. You can still manually include positions like before.
* Placeholder image is removed from the API response for products and images to make it easier to detect when no images are found.