### PR TITLE
Update woocommerce_currency setting to split out symbol

### DIFF
--- a/api/class-wc-rest-dev-setting-options-controller.php
+++ b/api/class-wc-rest-dev-setting-options-controller.php
@@ -26,4 +26,46 @@ class WC_REST_Dev_Setting_Options_Controller extends WC_REST_Setting_Options_Con
 	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Hooks into the automatically registered general settings group.
+	 */
+	public function get_group_settings( $group_id ) {
+		if ( 'general' === $group_id ) {
+			add_action( 'woocommerce_settings-general', array( $this, 'split_currency_setting_options' ) );
+		}
+		return parent::get_group_settings( $group_id );
+	}
+
+	/**
+	 * Takes the options array from `woocommerce_currency` and splits the currency value
+	 * into a label and symbol, so the currency currency symbol can easily be derived
+	 * from the API.
+	 */
+	public function split_currency_setting_options( $settings ) {
+		$setting_key = false;
+		foreach ( $settings as $key => $setting ) {
+			if ( 'woocommerce_currency' !== $setting['id'] ) {
+				continue;
+			}
+			$setting_key = $key;
+		}
+
+		if ( ! $setting_key ) {
+			return $settings;
+		}
+
+		$currencies   = get_woocommerce_currencies();
+		$prev_options = $settings[ $setting_key ]['options'];
+		$options      = array();
+		foreach ( $prev_options as $code => $full_string ) {
+			$options[ $code ] = array(
+				'label'  => $currencies[ $code ],
+				'symbol' => get_woocommerce_currency_symbol( $code ),
+			);
+		}
+		$settings[ $setting_key ]['options'] = $options;
+
+		return $settings;
+	}
+
 }

--- a/tests/unit-tests/settings.php
+++ b/tests/unit-tests/settings.php
@@ -752,4 +752,21 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'US:OR', $setting['options'] );
 	}
 
+	/**
+	 * Test getting the currency setting and making sure that its symbol and label are returned separately in the option response.
+	 */
+	public function test_get_currency_setting() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/general/woocommerce_currency' ) );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'woocommerce_currency', $data['id'] );
+		$this->assertEquals( array(
+			'label' => 'United States dollar',
+			'symbol' => '&#36;',
+		), $data['options']['USD'] );
+	}
+
 }


### PR DESCRIPTION
This PR updates the `woocommerce_currency` setting to split out the symbol and label from each other so that the current currency symbol can easily be derived from the API.

Previously, the options array would contain the following (based on how settings are registered in wp-admin and then passed to the API):

`USD: "United States dollar (&#36;)"`

Now with the new filter/code it will return:

`"USD": {
        "label": "United States dollar",
        "symbol": "&#36;"
},`

This fixes #2.

To Test:
* Run `phpunit` and make sure all tests pass.
* Make a request to `https://:site/wp-json/wc/v3/settings/general/woocommerce_currency` and make sure the new format is returned.
* Make a request to `https://:site/wp-json/wc/v3/settings/general` and make sure other options look correct.

cc @belcherj.