### PR TITLE
Filter in new settings for store address, address_2, city and postcode

### DIFF
--- a/api/class-wc-rest-dev-setting-options-controller.php
+++ b/api/class-wc-rest-dev-setting-options-controller.php
@@ -15,6 +15,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Filters new address settings into the settings general endpoint
+ *
+ * These new settings are being added to WC 3.x in
+ * pull request https://github.com/woocommerce/woocommerce/pull/15636
+ * This filter is used to insert them if not present.
+ *
+ * THIS FILTER SHOULD NOT BE PORTED TO WOOCOMMERCE CORE as the above PR
+ * already takes care of this in WooCommerce core.
+ */
+function wc_rest_dev_add_address_settings_to_settings_general( $settings ) {
+	$new_settings = array(
+		array(
+			'id' => 'woocommerce_store_address',
+			'type' => 'text',
+			'option_key' => 'woocommerce_store_address',
+			'default' => '',
+		),
+		array(
+			'id' => 'woocommerce_store_address_2',
+			'type' => 'text',
+			'option_key' => 'woocommerce_store_address_2',
+			'default' => '',
+		),
+		array(
+			'id' => 'woocommerce_store_city',
+			'type' => 'text',
+			'option_key' => 'woocommerce_store_city',
+			'default' => '',
+		),
+		array(
+			'id' => 'woocommerce_store_postcode',
+			'type' => 'text',
+			'option_key' => 'woocommerce_store_postcode',
+			'default' => '',
+		),
+	);
+
+	// For each of the new settings, make sure the setting id doesn't
+	// already exist in the settings array and then add it
+	$ids = array_column( $settings, 'id' );
+	foreach ( $new_settings as $new_setting ) {
+		if ( ! in_array( $new_setting['id'], $ids ) ) {
+			$settings[] = $new_setting;
+		}
+	}
+
+	return $settings;
+}
+add_filter( 'woocommerce_settings-general', 'wc_rest_dev_add_address_settings_to_settings_general', 999 );
+
+/**
  * REST API Setting Options controller class.
  *
  * @package WooCommerce/API


### PR DESCRIPTION
Fixes #12 

See also https://github.com/woocommerce/woocommerce/pull/15636

To test:
- Ensure GET wp-json/wc/v2/settings/general returns the new settings
- Ensure POSTing to wp-json/wc/v2/settings/general/{setting} stores the passed value for each of the following

woocommerce_store_address
woocommerce_store_address_2
woocommerce_store_city
woocommerce_store_postcode

- Ensure if this plugin is active at the same time as https://github.com/woocommerce/woocommerce/pull/15636 the the world doesn't asplode and that the GET response only returns each of the new settings once

