### PR TITLE
Payment Gateways: Add a `method_supports` property to each gateway response

### DIFF
--- a/api/class-wc-rest-dev-payment-gateways-controller.php
+++ b/api/class-wc-rest-dev-payment-gateways-controller.php
@@ -26,4 +26,163 @@ class WC_REST_Dev_Payment_Gateways_Controller extends WC_REST_Payment_Gateways_C
 	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Prepare a payment gateway for response.
+	 *
+	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
+	 * @param  WP_REST_Request    $request    Request object.
+	 * @return WP_REST_Response   $response   Response data.
+	 */
+	public function prepare_item_for_response( $gateway, $request ) {
+		$order  = (array) get_option( 'woocommerce_gateway_order' );
+		$item = array(
+			'id'                 => $gateway->id,
+			'title'              => $gateway->title,
+			'description'        => $gateway->description,
+			'order'              => isset( $order[ $gateway->id ] ) ? $order[ $gateway->id ] : '',
+			'enabled'            => ( 'yes' === $gateway->enabled ),
+			'method_title'       => $gateway->get_method_title(),
+			'method_description' => $gateway->get_method_description(),
+			'method_supports'    => $gateway->supports,
+			'settings'           => $this->get_settings( $gateway ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $item, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $gateway, $request ) );
+
+		/**
+		 * Filter payment gateway objects returned from the REST API.
+		 *
+		 * @param WP_REST_Response   $response The response object.
+		 * @param WC_Payment_Gateway $gateway  Payment gateway object.
+		 * @param WP_REST_Request    $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_payment_gateway', $response, $gateway, $request );
+	}
+
+	/**
+	 * Get the payment gateway schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'payment_gateway',
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Payment gateway ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'title' => array(
+					'description' => __( 'Payment gateway title on checkout.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description' => array(
+					'description' => __( 'Payment gateway description on checkout.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'order' => array(
+					'description' => __( 'Payment gateway sort order.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+				'enabled' => array(
+					'description' => __( 'Payment gateway enabled status.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'method_title' => array(
+					'description' => __( 'Payment gateway method title.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'method_description' => array(
+					'description' => __( 'Payment gateway method description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'method_supports' => array(
+					'description' => __( 'Supported features for this payment gateway.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
+				'settings' => array(
+					'description' => __( 'Payment gateway settings.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'A unique identifier for the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'label' => array(
+							'description' => __( 'A human readable label for the setting used in interfaces.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'description' => array(
+							'description' => __( 'A human readable description for the setting used in interfaces.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'type' => array(
+							'description' => __( 'Type of setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'enum'        => array( 'text', 'email', 'number', 'color', 'password', 'textarea', 'select', 'multiselect', 'radio', 'image_width', 'checkbox' ),
+							'readonly'    => true,
+						),
+						'value' => array(
+							'description' => __( 'Setting value.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'default' => array(
+							'description' => __( 'Default value for the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'tip' => array(
+							'description' => __( 'Additional help text shown to the user about the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'placeholder' => array(
+							'description' => __( 'Placeholder text to be displayed in text inputs.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/tests/unit-tests/payment-gateways.php
+++ b/tests/unit-tests/payment-gateways.php
@@ -50,6 +50,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 			'enabled'            => true,
 			'method_title'       => 'Check payments',
 			'method_description' => 'Allows check payments. Why would you take checks in this day and age? Well you probably would not, but it does allow you to make test purchases for testing order emails and the success pages.',
+			'method_supports'    => array( 'products' ),
 			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Cheque' ), array( 'enabled' => false, 'description' => false ) ),
 			'_links' => array(
 				'self'       => array(
@@ -97,6 +98,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 			'enabled'            => true,
 			'method_title'       => 'PayPal',
 			'method_description' => 'PayPal Standard sends customers to PayPal to enter their payment information. PayPal IPN requires fsockopen/cURL support to update order statuses after payment. Check the <a href="http://example.org/wp-admin/admin.php?page=wc-status">system status</a> page for more details.',
+			'method_supports'    => array( 'products', 'refunds' ),
 			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Paypal' ), array( 'enabled' => false, 'description' => false ) ),
 		), $paypal );
 	}
@@ -252,7 +254,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 8, count( $properties ) );
+		$this->assertEquals( 9, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
@@ -260,6 +262,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'enabled', $properties );
 		$this->assertArrayHasKey( 'method_title', $properties );
 		$this->assertArrayHasKey( 'method_description', $properties );
+		$this->assertArrayHasKey( 'method_supports', $properties );
 		$this->assertArrayHasKey( 'settings', $properties );
 	}
 


### PR DESCRIPTION
Fixes #17

To test:

- Check that each gateway in `GET /wc/v3/payment_gateways` has a `method_supports` property, which should be an array
- Check that a single gateway has the `method_supports` prop (ex: `GET /wc/v3/payment_gateways/bacs`)
- Run `phpunit` to check the tests