### PR TITLE
Disable jetpack sync during REST requests

### DIFF
--- a/hotfixes/wc-api-dev-jetpack-hotfixes.php
+++ b/hotfixes/wc-api-dev-jetpack-hotfixes.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Jetpack compatibility hotfixes
+ *
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Disables jetpack sync during rest requests to avoid lengthly (> 5 second) response
+ * times during the shutdown action for things like product creation
+ *
+ * See also https://core.trac.wordpress.org/ticket/41358#ticket
+ * See also https://github.com/Automattic/jetpack/pull/7482
+ *
+ * This can be removed once we have either of the two fixes above released
+ * 
+ * See also https://github.com/woocommerce/woocommerce/pull/16158
+ */
+
+function wc_api_dev_jetpack_sync_sender_should_load( $sender_should_load ) {
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		$sender_should_load = false;
+	}
+
+	return $sender_should_load;
+}
+
+add_filter( 'jetpack_sync_sender_should_load', 'wc_api_dev_jetpack_sync_sender_should_load', 999 );

--- a/hotfixes/wc-api-dev-jetpack-hotfixes.php
+++ b/hotfixes/wc-api-dev-jetpack-hotfixes.php
@@ -22,7 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 
 function wc_api_dev_jetpack_sync_sender_should_load( $sender_should_load ) {
-	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+	$starts_with = '/wp-json/wc/v';
+	if ( $starts_with === substr( $_SERVER[ 'REQUEST_URI' ], 0, strlen( $starts_with ) ) ) {
 		$sender_should_load = false;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce, rest-api, api
 Requires at least: 4.6
 Tested up to: 4.8
-Stable tag: 0.6.0
+Stable tag: 0.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 0.7.0 =
+* Fix - disable jetpack sync during rest api requests to avoid slow responses
 
 = 0.6.0 =
 * Fix value default return on settings endpoints

--- a/wc-api-dev.php
+++ b/wc-api-dev.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce API Dev
  * Plugin URI: https://woocommerce.com/
  * Description: A feature plugin providing a bleeding edge version of the WooCommerce REST API.
- * Version: 0.6.0
+ * Version: 0.7.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Requires at least: 4.4
@@ -117,6 +117,9 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-system-status-tools-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-shipping-methods-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-payment-gateways-controller.php' );
+
+		// Things that aren't related to a specific endpoint but to things like cross-plugin compatibility
+		include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-jetpack-hotfixes.php' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #27 

To test:
* Use a tool like Postman to create a product using the REST API
* Note the horribly long creation time (e.g. approx 5 seconds)
* Install this branch
* Create another product
* Note the wonderfully short creation time (e.g. approx 2 seconds)
* Profit!

Note: Bumps version to 0.7.0 also

cc @justinshreve or @DanReyLop for review
cc @westi 