### PR TITLE
Add another URI for which to disable jetpack sync

### DIFF
--- a/hotfixes/wc-api-dev-jetpack-hotfixes.php
+++ b/hotfixes/wc-api-dev-jetpack-hotfixes.php
@@ -16,15 +16,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * See also https://core.trac.wordpress.org/ticket/41358#ticket
  * See also https://github.com/Automattic/jetpack/pull/7482
  *
- * This can be removed once we have either of the two fixes above released
+ * This can be removed once we have either of the two fixes above released. The first
+ * trigger string is typical of a direct request (e.g. ala Postman) and the second
+ * trigger string is typical of a request from WordPress.com for Jetpack.
  * 
  * See also https://github.com/woocommerce/woocommerce/pull/16158
+ *
+ * @since 0.7.0
+ * @version 0.7.1
  */
 
 function wc_api_dev_jetpack_sync_sender_should_load( $sender_should_load ) {
-	$starts_with = '/wp-json/wc/v';
-	if ( $starts_with === substr( $_SERVER[ 'REQUEST_URI' ], 0, strlen( $starts_with ) ) ) {
-		$sender_should_load = false;
+	$trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
+
+	error_log( $_SERVER[ 'REQUEST_URI' ] );
+	foreach( $trigger_strings as $trigger_string ) {
+		if ( $trigger_string === substr( $_SERVER[ 'REQUEST_URI' ], 0, strlen( $trigger_string ) ) ) {
+			$sender_should_load = false;
+			break;
+		}
 	}
 
 	return $sender_should_load;

--- a/hotfixes/wc-api-dev-jetpack-hotfixes.php
+++ b/hotfixes/wc-api-dev-jetpack-hotfixes.php
@@ -30,7 +30,7 @@ function wc_api_dev_jetpack_sync_sender_should_load( $sender_should_load ) {
 	$trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
 
 	foreach( $trigger_strings as $trigger_string ) {
-		if ( $trigger_string === substr( $_SERVER[ 'REQUEST_URI' ], 0, strlen( $trigger_string ) ) ) {
+		if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $trigger_string ) ) {
 			$sender_should_load = false;
 			break;
 		}

--- a/hotfixes/wc-api-dev-jetpack-hotfixes.php
+++ b/hotfixes/wc-api-dev-jetpack-hotfixes.php
@@ -29,7 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wc_api_dev_jetpack_sync_sender_should_load( $sender_should_load ) {
 	$trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
 
-	error_log( $_SERVER[ 'REQUEST_URI' ] );
 	foreach( $trigger_strings as $trigger_string ) {
 		if ( $trigger_string === substr( $_SERVER[ 'REQUEST_URI' ], 0, strlen( $trigger_string ) ) ) {
 			$sender_should_load = false;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce, rest-api, api
 Requires at least: 4.6
 Tested up to: 4.8
-Stable tag: 0.7.0
+Stable tag: 0.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 0.7.1 =
+* Fix - add another URI to watch for when disabling sync during API requests
 
 = 0.7.0 =
 * Fix - disable jetpack sync during rest api requests to avoid slow responses

--- a/wc-api-dev.php
+++ b/wc-api-dev.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce API Dev
  * Plugin URI: https://woocommerce.com/
  * Description: A feature plugin providing a bleeding edge version of the WooCommerce REST API.
- * Version: 0.7.0
+ * Version: 0.7.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Requires at least: 4.4


### PR DESCRIPTION
The previous PR only worked for Postman initiated requests. This PR also catches requests originating from WordPress.com correctly.

I've tested it with https://github.com/Automattic/rest-api-perf-test-private (which does the jetpack requests through WordPress.com) and postman too if you want to just review the code without testing.