### PR TITLE
Add Customizer Guided Tour

### DIFF
--- a/assets/css/admin/customizer.css
+++ b/assets/css/admin/customizer.css
@@ -1,0 +1,235 @@
+.sf-nux .sf-nux-button,
+a.sf-nux-button {
+	background: #00aadc;
+	border-color: #0087be;
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	color: #fff;
+	cursor: pointer;
+	display: inline-block;
+	outline: 0;
+	overflow: hidden;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	text-transform: none;
+	text-shadow: none;
+	box-sizing: border-box;
+	font-size: 14px;
+	height: auto;
+	line-height: 21px;
+	border-radius: 4px;
+	margin: 0;
+	padding: 7px 14px 9px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	vertical-align: baseline;
+}
+
+a.sf-button-secondary {
+	background: #e9eff3;
+	border-color: #c8d7e1;
+	color: #2e4453;
+}
+
+.sf-nux .sf-nux-button:focus,
+.sf-nux .sf-nux-button:hover,
+a.sf-nux-button:focus,
+a.sf-nux-button:hover {
+	border-color: #005082;
+	color: #fff;
+}
+
+a.sf-button-secondary:focus,
+a.sf-button-secondary:hover {
+	border-color: #a8bece;
+	color: #2e4453;
+}
+
+.sf-nux .sf-nux-button:focus,
+a.sf-nux-button:focus {
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+.sf-nux .sf-nux-button:active,
+a.sf-nux-button:active {
+	border-width: 2px 1px 1px;
+	box-shadow: none;
+	vertical-align: baseline;
+}
+
+.sf-nux .sf-nux-button:disabled,
+.sf-nux .sf-nux-button[disabled],
+a.sf-nux-button:disabled,
+a.sf-nux-button[disabled] {
+	color: #fff;
+	background: tint(#78dcfa,50%);
+	border-color: tint(#0087be,55%);
+	cursor: default;
+}
+
+.sf-nux .sf-nux-button:disabled:active,
+.sf-nux .sf-nux-button[disabled]:active,
+a.sf-nux-button:disabled:active,
+a.sf-nux-button[disabled]:active {
+	border-width: 1px 1px 2px;
+}
+
+.sf-guided-tour {
+	display: block;
+	background-color: #23282d;
+	background-color: rgba(35,40,45,.95);
+	border-radius: 5px;
+	box-shadow: 3px 1px 5px -2px rgba(0,0,0,.145);
+	color: #a4a4a4;
+	font-size: 1.1em;
+	z-index: 999999998; /* lol! */
+	text-align: left;
+	box-sizing: border-box;
+	position: fixed;
+	left: 5px;
+	width: 430px;
+	-webkit-transition-duration: 250ms;
+	transition-duration: 250ms;
+	-webkit-transition-property: opacity;
+	transition-property: opacity;
+	-webkit-transition-timing-function: ease-in-out;
+	transition-timing-function: ease-in-out;
+	opacity: 0;
+}
+
+.sf-guided-tour:before {
+	content: '';
+	position: absolute;
+	top: 30px;
+	left: -14px;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-width: 14px 14px 14px 0;
+	border-color: transparent #23282d transparent transparent;
+}
+
+.sf-guided-tour .sf-guided-tour-step {
+	padding: 30px;
+	overflow: hidden;
+}
+
+.sf-guided-tour .sf-guided-tour-step p {
+	font-size: 1em;
+	line-height: 1.7;
+}
+
+.sf-guided-tour .sf-guided-tour-step h2 {
+	margin-top: 0;
+	font-size: 1.1em;
+	font-weight: 500;
+	color: #fff;
+}
+
+.sf-guided-tour .sf-guided-tour-step .sf-guided-tour-skip {
+	margin-left: 10px;
+	color: #00aadc;
+}
+
+.sf-guided-tour .sf-guided-tour-step .sf-guided-tour-skip:hover {
+	opacity:.75;
+}
+
+.sf-guided-tour.sf-inside-section .sf-guided-tour-step a.sf-nux-button {
+	display: inline-block;
+}
+
+.sf-guided-tour.sf-inside-section .sf-guided-tour-step .sf-guided-tour-skip {
+	display: none;
+}
+
+.sf-guided-tour.sf-last-step .sf-guided-tour-step a.sf-nux-button {
+	display: inline-block;
+}
+
+a.sf-nux-button {
+	vertical-align: middle;
+}
+
+a.sf-nux-button:active {
+	vertical-align: middle;
+}
+
+.sf-loaded {
+	opacity: 1;
+}
+
+.sf-moving {
+	-webkit-transition-duration: 250ms;
+	transition-duration: 250ms;
+	-webkit-transition-property: -webkit-transform;
+	transition-property: -webkit-transform;
+	transition-property: transform;
+	transition-property: transform , -webkit-transform;
+	-webkit-transition-timing-function: cubic-bezier(.84,.45,.68,1.44);
+	transition-timing-function: cubic-bezier(.84,.45,.68,1.44);
+}
+
+.sf-entering .sf-guided-tour,
+.sf-exiting .sf-guided-tour {
+	animation-duration: .3s;
+	animation-timing-function: ease-in-out;
+	-webkit-animation-duration: .3s;
+	-webkit-animation-timing-function: ease-in-out;
+}
+
+.sf-entering .sf-guided-tour {
+	animation-name: bounceInLeft;
+	-webkit-animation-name: bounceInLeft;
+}
+
+.sf-exiting .sf-guided-tour {
+	animation-name: bounceOutRight;
+	-webkit-animation-name: bounceOutRight;
+}
+
+@-webkit-keyframes bounceInLeft {
+	from {
+		opacity: 0;
+		-webkit-transform: translateX(100%);
+	}
+	to {
+		opacity: 1;
+		-webkit-transform: translateX(0);
+	}
+}
+
+@keyframes bounceInLeft {
+	from {
+		opacity: 0;
+		-webkit-transform: translateX(100%);
+		transform: translateX(100%);
+	}
+	to {
+		opacity: 1;
+		-webkit-transform: translateX(0);
+		transform: translateX(0);
+	}
+}
+
+@-webkit-keyframes bounceOutRight {
+	to {
+		opacity: 0;
+		-webkit-transform: translateX(100%);
+	}
+}
+
+@keyframes bounceOutRight {
+	to {
+		opacity: 0;
+		-webkit-transform: translateX(100%);
+		transform: translateX(100%);
+	}
+}
+
+.sf-guided-tour ul {
+	list-style: initial;
+	margin-left: 18px;
+}

--- a/assets/css/admin/customizer.css
+++ b/assets/css/admin/customizer.css
@@ -129,7 +129,6 @@ a.sf-nux-button[disabled]:active {
 }
 
 .sf-guided-tour .sf-guided-tour-step .sf-guided-tour-skip {
-	margin-left: 10px;
 	color: #00aadc;
 }
 
@@ -139,10 +138,6 @@ a.sf-nux-button[disabled]:active {
 
 .sf-guided-tour.sf-inside-section .sf-guided-tour-step a.sf-nux-button {
 	display: inline-block;
-}
-
-.sf-guided-tour.sf-inside-section .sf-guided-tour-step .sf-guided-tour-skip {
-	display: none;
 }
 
 .sf-guided-tour.sf-last-step .sf-guided-tour-step a.sf-nux-button {

--- a/assets/css/admin/customizer.css
+++ b/assets/css/admin/customizer.css
@@ -228,3 +228,16 @@ a.sf-nux-button:active {
 	list-style: initial;
 	margin-left: 18px;
 }
+
+.sf-guided-tour-close {
+	display: none;
+	position: fixed;
+	top: 10px;
+	right: 10px;
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.sf-show-close .sf-guided-tour-close {
+	display: block;
+}

--- a/assets/css/admin/customizer.css
+++ b/assets/css/admin/customizer.css
@@ -247,7 +247,13 @@ a.sf-nux-button:active {
 	color: #f0b849;
 }
 
-#customize-controls .customize-info .customize-panel-description .sf-customize-alert-message {
+#customize-controls .customize-info .customize-panel-description p.sf-customize-alert-message {
 	background-color: #f0b849;
-	padding: 8px;
+	padding: 15px;
+	margin: -12px -15px 12px;
+	color: #5B3F06;
+}
+
+#customize-controls .customize-info .customize-panel-description p.sf-customize-alert-message a {
+	color: #5B3F06;
 }

--- a/assets/css/admin/customizer.css
+++ b/assets/css/admin/customizer.css
@@ -241,3 +241,13 @@ a.sf-nux-button:active {
 .sf-show-close .sf-guided-tour-close {
 	display: block;
 }
+
+#customize-controls .customize-info.sf-customize-alert .customize-help-toggle,
+#customize-controls .customize-info.sf-customize-alert.open .customize-help-toggle {
+	color: #f0b849;
+}
+
+#customize-controls .customize-info .customize-panel-description .sf-customize-alert-message {
+	background-color: #f0b849;
+	padding: 8px;
+}

--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -1,0 +1,282 @@
+/* global _wpCustomizeWcApiDevGuidedTourSteps */
+( function( wp, $ ) {
+	'use strict';
+
+	if ( ! wp || ! wp.customize ) { return; }
+
+	// Set up our namespace.
+	var api = wp.customize;
+
+	api.WcApiDevGuidedTourSteps = [];
+
+	if ( 'undefined' !== typeof _wpCustomizeWcApiDevGuidedTourSteps ) {
+		$.extend( api.WcApiDevGuidedTourSteps, _wpCustomizeWcApiDevGuidedTourSteps );
+	}
+
+	/**
+	 * wp.customize.SFGuidedTour
+	 *
+	 */
+	api.WcApiDevGuidedTour = {
+		$container: null,
+		currentStep: -1,
+
+		init: function() {
+			console.log( 'WcApiDevGuidedTour.init()' );
+			this._setupUI();
+		},
+
+		_setupUI: function() {
+			var self = this,
+			    $wpCustomize = $( 'body.wp-customizer .wp-full-overlay' );
+
+			this.$container = $( '<div/>' ).addClass( 'sf-guided-tour' );
+
+			// Add guided tour div
+			$wpCustomize.prepend( this.$container );
+
+			// Add listeners
+			this._addListeners();
+
+			// Initial position
+			this.$container.css( 'left', ( $( '#customize-controls' ).width() + 10 ) + 'px' ).on( 'transitionend', function() {
+				self.$container.addClass( 'sf-loaded' );
+			});
+
+			// Show first step
+			this._showNextStep();
+
+			$( document ).on( 'click', '.sf-guided-tour-step .sf-nux-alt-button', function() {
+				self._doAltStep();
+				return false;
+			});
+
+			$( document ).on( 'click', '.sf-guided-tour-step .sf-nux-primary-button', function() {
+				self._showNextStep();
+				return false;
+			});
+
+			$( document ).on( 'click', '.sf-guided-tour-step .sf-guided-tour-skip', function() {
+				if ( 0 === self.currentStep ) {
+					self._hideTour( true );
+				} else {
+					self._showNextStep();
+				}
+
+				return false;
+			});
+		},
+
+		_addListeners: function() {
+			var self = this;
+
+			api.state( 'expandedSection' ).bind( function() {
+				self._adjustPosition();
+			});
+
+			api.state( 'expandedPanel' ).bind( function() {
+				self._adjustPosition();
+			});
+
+			window.onbeforeunload = function( e ) {
+				self._hideTour( true );
+			};
+		},
+
+		_doAltStep: function() {
+			var step = this._getCurrentStep(),
+				self = this;
+
+			switch ( step.alt_step.action ) {
+				case 'expandThemes':
+					var nextStep, themePanel;
+					themePanel = api.section.instance( 'themes' );
+					console.log( themePanel );
+					themePanel.expand();
+					
+					nextStep = step.alt_step;
+					delete( nextStep.button_text );
+					self._renderStep( nextStep );
+				break;
+
+				case 'exit':
+					this._hideTour( true );
+				break;
+			}
+		},
+
+		_adjustPosition: function() {
+			var step            = this._getCurrentStep(),
+				expandedSection = api.state( 'expandedSection' ).get(),
+				expandedPanel   = api.state( 'expandedPanel' ).get();
+
+			if ( ! step ) {
+				return;
+			}
+
+			this.$container.removeClass( 'sf-inside-section' );
+
+			if ( expandedSection && step.section === expandedSection.id ) {
+				this._moveContainer( $( expandedSection.container[1] ).find( '.customize-section-title' ) );
+				this.$container.addClass( 'sf-inside-section' );
+			} else if ( false === expandedSection && false === expandedPanel ) {
+				if ( this._isTourHidden() ) {
+					this._revealTour();
+				} else {
+					var selector = this._getSelector( step.section );
+					this._moveContainer( selector );
+				}
+			} else {
+				this._hideTour();
+			}
+		},
+
+		_hideTour: function( remove ) {
+			var self = this;
+
+			// Already hidden?
+			if ( this._isTourHidden() ) {
+				return;
+			}
+
+			this.$container.css({
+				transform: '',
+				top: this.$container.offset().top
+			});
+
+			$( 'body' ).addClass( 'sf-exiting' ).on( 'animationend.storefront webkitAnimationEnd.storefront', function() {
+				$( this ).removeClass( 'sf-exiting' ).off( 'animationend.storefront webkitAnimationEnd.storefront' ).addClass( 'sf-hidden' );
+				self.$container.hide();
+
+				if ( ! _.isUndefined( remove ) && true === remove ) {
+					self._removeTour();
+				}
+			});
+		},
+
+		_revealTour: function() {
+			 var self = this;
+
+			$( 'body' ).removeClass( 'sf-hidden' );
+
+			self.$container.show();
+
+			$( 'body' ).addClass( 'sf-entering' ).on( 'animationend.storefront webkitAnimationEnd.storefront', function() {
+				$( this ).removeClass( 'sf-entering' ).off( 'animationend.storefront webkitAnimationEnd.storefront' );
+
+				self.$container.css({
+					top: 'auto',
+					transform: 'translateY(' + parseInt( self.$container.offset().top, 10 ) + 'px)'
+				});
+			});
+		},
+
+		_removeTour: function() {
+			this.$container.remove();
+		},
+
+		_closeAllSections: function() {
+			api.section.each( function ( section ) {
+				section.collapse( { duration: 0 } );
+			});
+
+			api.panel.each( function ( panel ) {
+				panel.collapse( { duration: 0 } );
+			});
+		},
+
+		_showNextStep: function() {
+			var step, template;
+
+			if ( this._isLastStep() ) {
+				this._hideTour( true );
+				return;
+			}
+
+			this._closeAllSections();
+
+			// Get next step
+			step = this._getNextStep();
+
+			this._renderStep( step );
+		},
+
+		_renderStep: function( step ) {
+			var template;
+			// Convert line breaks to paragraphs
+			step.message = this._lineBreaksToParagraphs( step.message );
+
+			// Load template
+			template = wp.template( 'wc-api-guided-tour-step' );
+
+			this.$container.removeClass( 'sf-first-step' );
+
+			if ( 0 === this.currentStep ) {
+				step.first_step = true;
+				this.$container.addClass( 'sf-first-step' );
+			}
+
+			if ( this._isLastStep() ) {
+				step.last_step = true;
+				this.$container.addClass( 'sf-last-step' );
+			}
+
+			this._moveContainer( this._getSelector( step.section ) );
+
+			this.$container.html( template( step ) );
+		},
+
+		_moveContainer: function( $selector ) {
+			var self = this, position;
+
+			if ( ! $selector ) {
+				return;
+			}
+
+			position = parseInt( $selector.offset().top, 10 ) + ( $selector.height() / 2 ) - 44;
+
+			this.$container.addClass( 'sf-moving' ).css({ 'transform': 'translateY(' + parseInt( position, 10 ) + 'px)' }).on( 'transitionend.storefront', function() {
+				self.$container.removeClass( 'sf-moving' );
+				self.$container.off( 'transitionend.storefront' );
+			} );
+		},
+
+		_getSelector: function( pointTo ) {
+			var section = api.section( pointTo );
+
+			// Check whether this is a section or a regular selector
+			if ( ! _.isUndefined( section ) ) {
+				return $( section.container[0] );
+			}
+
+			return $( pointTo );
+		},
+
+		_getCurrentStep: function() {
+			return api.WcApiDevGuidedTourSteps[ this.currentStep ];
+		},
+
+		_getNextStep: function() {
+			this.currentStep = this.currentStep + 1;
+			return api.WcApiDevGuidedTourSteps[ this.currentStep ];
+		},
+
+		_isTourHidden: function() {
+			return ( ( $( 'body' ).hasClass( 'sf-hidden' ) ) ? true : false );
+		},
+
+		_isLastStep: function() {
+			return ( ( ( this.currentStep + 1 ) < api.WcApiDevGuidedTourSteps.length ) ? false : true );
+		},
+
+		_lineBreaksToParagraphs: function( message ) {
+			return '<p>' + message.replace( '\n\n', '</p><p>' ) + '</p>';
+		}
+	};
+
+	$( document ).ready( function() {
+		console.log( 'ready' );
+		api.WcApiDevGuidedTour.init();
+	});
+} )( window.wp, jQuery );
+

--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -31,7 +31,6 @@
 
 		init: function() {
 			this._setupUI();
-			bumpStat( 'tour-start' );
 		},
 
 		_setupUI: function() {
@@ -65,6 +64,11 @@
 			});
 
 			$( document ).on( 'click', '.sf-guided-tour-step .sf-guided-tour-skip', function() {
+				var step = self._getCurrentStep();
+				if ( step.stat ) {
+					bumpStat( step.stat + '-skip' );
+				}
+
 				if ( 0 === self.currentStep ) {
 					self._hideTour( true );
 				} else {
@@ -129,7 +133,6 @@
 				}
 
 				if ( e && e.target && e.target.value === 'page' ) {
-					bumpStat( 'set-home-to-page' );
 					// User has toggled proceed to next step
 					self._showNextStep();
 				}
@@ -148,7 +151,6 @@
 
 				// Obvioulsy won't work for non enUs
 				if ( $(' #_customize-dropdown-pages-page_on_front option:selected' ).text() === 'Shop' ) {
-					bumpStat( 'set-home-to-shop' );
 					self._showNextStep();
 				}
 			} );
@@ -167,12 +169,16 @@
 					nextStep = step.altStep;
 					delete( nextStep.buttonText );
 					self._renderStep( nextStep );
-					bumpStat( 'try-storefront' );
+					if ( step.stat ) {
+						bumpStat( step.stat );
+					}
 				break;
 
 				case 'exit':
-					bumpStat( 'exit-step-2' );
 					this._hideTour( true );
+					if ( step.stat ) {
+						bumpStat( step.stat );
+					}
 				break;
 			}
 		},
@@ -219,7 +225,6 @@
 							self._hideTour();
 							return;
 						}
-						bumpStat( 'entered-menu' );
 
 						// Adjust the left attribute of the container
 						self.$container.css( 'left', ( $( '#available-menu-items-search' ).width() + currentLeft ) + 'px' );
@@ -242,7 +247,6 @@
 						}
 
 						self.childTourStep += 1;
-						bumpStat( 'added-menu-item' );
 
 						if ( step.childSteps[ self.childTourStep ] ) {
 							self._renderStep( step.childSteps[ self.childTourStep ] );
@@ -355,12 +359,10 @@
 				switch ( step.action ) {
 					case 'addLogo':
 						api.section.instance( 'title_tagline' ).expand();
-						bumpStat( 'logo-step' );
 					break;
 
 					case 'updateMenus':
 						api.panel( 'nav_menus' ).expand();
-						bumpStat( 'menu-step' );
 					break;
 
 					case 'resetChildTour':
@@ -409,6 +411,10 @@
 
 			this.$container.removeClass( 'sf-first-step' );
 			this.$container.removeClass( 'sf-show-close' );
+
+			if ( step.stat ) {
+				bumpStat( step.stat );
+			}
 
 			if ( 0 === this.currentStep ) {
 				step.first_step = true;

--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -22,7 +22,6 @@
 		currentStep: -1,
 
 		init: function() {
-			console.log( 'WcApiDevGuidedTour.init()' );
 			this._setupUI();
 		},
 
@@ -91,7 +90,6 @@
 				case 'expandThemes':
 					var nextStep, themePanel;
 					themePanel = api.section.instance( 'themes' );
-					console.log( themePanel );
 					themePanel.expand();
 					
 					nextStep = step.alt_step;
@@ -115,9 +113,11 @@
 			}
 
 			this.$container.removeClass( 'sf-inside-section' );
-
 			if ( expandedSection && step.section === expandedSection.id ) {
 				this._moveContainer( $( expandedSection.container[1] ).find( '.customize-section-title' ) );
+				this.$container.addClass( 'sf-inside-section' );
+			} else if ( expandedPanel && step.panel === expandedPanel.id ) {
+				this._moveContainer( $( expandedPanel.container[1] ).find( step.panelSection ) );
 				this.$container.addClass( 'sf-inside-section' );
 			} else if ( false === expandedSection && false === expandedPanel ) {
 				if ( this._isTourHidden() ) {
@@ -193,10 +193,23 @@
 				return;
 			}
 
-			this._closeAllSections();
-
 			// Get next step
 			step = this._getNextStep();
+
+			// Does this have a custom action?
+			if ( step.action ) {
+				switch ( step.action ) {
+					case 'addLogo':
+						api.section.instance('title_tagline').expand();
+					break;
+
+					case 'updateMenus':
+						api.panel('nav_menus').expand();
+					break;
+				}
+			} else {
+				this._closeAllSections();
+			}
 
 			this._renderStep( step );
 		},
@@ -275,7 +288,6 @@
 	};
 
 	$( document ).ready( function() {
-		console.log( 'ready' );
 		api.WcApiDevGuidedTour.init();
 	});
 } )( window.wp, jQuery );

--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -1,4 +1,4 @@
-/* global _wpCustomizeWcApiDevGuidedTourSteps */
+/* global _wpCustomizeWcApiDevGuidedTourSteps, _wpCustomizeWcApiDevGuidedSettings */
 ( function( wp, $ ) {
 	'use strict';
 
@@ -6,6 +6,7 @@
 
 	// Set up our namespace.
 	var api = wp.customize;
+	var settings = _wpCustomizeWcApiDevGuidedSettings || {};
 
 	api.WcApiDevGuidedTourSteps = [];
 
@@ -14,7 +15,7 @@
 	}
 
 	/**
-	 * wp.customize.SFGuidedTour
+	 * wp.customize.WcApiDevGuidedTour
 	 *
 	 */
 	api.WcApiDevGuidedTour = {
@@ -354,7 +355,7 @@
 						api.Menus.availableMenuItemsPanel.close();
 
 						// collapse menu panel
-						api.panel('nav_menus').collapse();						
+						api.panel('nav_menus').collapse();
 
 						// open homepage section
 						api.section('static_front_page').expand();
@@ -389,12 +390,7 @@
 		},
 
 		_renderStep: function( step ) {
-			var template;
-			// Convert line breaks to paragraphs
-			step.message = this._lineBreaksToParagraphs( step.message );
-
-			// Load template
-			template = wp.template( 'wc-api-guided-tour-step' );
+			var template = wp.template( 'wc-api-guided-tour-step' );
 
 			this.$container.removeClass( 'sf-first-step' );
 			this.$container.removeClass( 'sf-show-close' );
@@ -460,13 +456,32 @@
 			return ( ( ( this.currentStep + 1 ) < api.WcApiDevGuidedTourSteps.length ) ? false : true );
 		},
 
-		_lineBreaksToParagraphs: function( message ) {
-			return '<p>' + message.replace( '\n\n', '</p><p>' ) + '</p>';
-		}
+		showAlert: function() {
+			var helpButton = $( '#customize-info button.customize-help-toggle' ), customizeInfoPanel, customizeInfoMessagePanel, currentMessage;
+
+			// Remove some classes, add some others.
+			customizeInfoPanel = $( '#customize-info' );
+			customizeInfoPanel.addClass( 'sf-customize-alert' );
+			helpButton.removeClass( 'dashicons-editor-help' );
+			helpButton.addClass( 'dashicons-warning' );
+
+			// Inject warning message.
+			customizeInfoMessagePanel = customizeInfoPanel.find( '.customize-panel-description' );
+			currentMessage = customizeInfoMessagePanel.text();
+			customizeInfoMessagePanel.html(
+				'<p class="sf-customize-alert-message">' + settings.alertMessage + '</p><p>' + currentMessage + '</p>'
+			);
+		},
 	};
 
 	$( document ).ready( function() {
-		api.WcApiDevGuidedTour.init();
+		if ( settings.autoStartTour ) {
+			api.WcApiDevGuidedTour.init();
+		}
+
+		if ( settings.showTourAlert ) {
+			api.WcApiDevGuidedTour.showAlert();
+		}
 	});
 } )( window.wp, jQuery );
 

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -63,9 +63,9 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 		public function customize_scripts() {
 			global $storefront_version;
 
-			wp_enqueue_style( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/css/admin/customizer.css', array(), $storefront_version, 'all' );
+			wp_enqueue_style( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/css/admin/customizer.css', array(), WC_API_Dev::CURRENT_VERSION, 'all' );
 
-			wp_enqueue_script( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/js/admin/customizer.js', array( 'jquery', 'wp-backbone' ), $storefront_version, true );
+			wp_enqueue_script( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/js/admin/customizer.js', array( 'jquery', 'wp-backbone' ), WC_API_Dev::CURRENT_VERSION, true );
 
 			wp_localize_script( 'wc-store-nux-tour', '_wpStoreNuxTourSteps', $this->guided_tour_steps() );
 			wp_localize_script( 'wc-store-nux-tour', '_wpStoreNuxSettings', $this->guided_tour_settings() );
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			return array(
 				'autoStartTour' => ( bool ) $show_tour,
-				'showTourAlert' => ( bool ) ! $show_tour,
+				'showTourAlert' => ( bool ) ! $theme_supports_woo && ! in_array( $current_theme, $supported_themes ),
 				'alertMessage'  => sprintf( __( '%1$sYour current theme isn\'t ready for store features yet%2$s. Consequently your shop and product page layouts might display incorrectly.%3$sWe reccomend switching themes to %1$sStorefront%2$s. %4$sClick here%5$s to get started.%3$s %6$sLearn more about Storefront%5$s', 'storefront' ), '<strong>', '</strong>', '<br><br>', '<a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">', '</a>', '<a href="https://woocommerce.com/storefront/" target="_blank">' ),
 			);
 		}

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -118,8 +118,8 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			$theme_supports_woo = current_theme_supports( 'woocommerce' );
 
 			return array(
-				'autoStartTour' => $show_tour && ! $theme_supports_woo,
-				'showTourAlert' => ! $show_tour && ! $theme_supports_woo,
+				'autoStartTour' => ( bool ) $show_tour,
+				'showTourAlert' => ( bool ) ! $show_tour,
 				'alertMessage'  => __( 'It looks like your current theme isn\'t ready for shop features yet - your shop and product pages might look a little funny.<br/><br/>We reccomend switching themes to Storefront. <a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">Click here</a> to get started.', 'storefront' ),
 			);
 		}
@@ -178,7 +178,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'panel'        => 'nav_menus',
 				'panelSection' => '.control-section-nav_menu',
 				'action'       => 'updateMenus',
-				'showSkip'     => 'true',
+				'showSkip'     => ( bool ) true,
 				'childSteps'   => array(
 					array(
 						'message'    => __( '<p>Here are the items currently added to your menu. Click the "Add Items" button.</p>', 'storefront' ),
@@ -204,8 +204,8 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 					'message'      => __( '<p>If you would like to set your shop page as your homepage select the "A static page" option.</p>', 'storefront' ),
 					'section'      => '#customize-control-show_on_front',
 					'action'       => 'resetChildTour',
-					'showSkip'     => true,
-					'suppressHide' => true,
+					'showSkip'     => ( bool ) true,
+					'suppressHide' => ( bool ) true,
 				);
 			}
 
@@ -213,7 +213,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'message'      => __( '<p>Select which page you\'d like to set as your homepage. If you want your shop to be the focal point of your site then choosing the "Shop" page would be a good choice.</p>', 'storefront' ),
 				'section'      => '#_customize-dropdown-pages-page_on_front',
 				'action'       => $show_on_front == 'page' ? 'resetChildTour' : 'verifyHomepage',
-				'showSkip'     => true,
+				'showSkip'     => ( bool ) true,
 				'suppressHide' => $show_on_front == 'page' ? true : false,
 			);
 

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -140,12 +140,14 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'buttonText'  => __( 'I\'ll keep my current theme', 'storefront' ),
 				'section'     => '#customize-info',
 				'className'   => 'sf-button-secondary',
+				'stat'        => '1-keep-try-step',
 				'altStep'     => array(
 					'buttonText'  => __( 'I\'ll try Storefront!', 'storefront' ),
 					'action'      => 'expandThemes',
 					'message'     => __( 'Click the thumbnail to get started with Storefront', 'storefront' ),
 					'section'     => '#customize-control-theme_storefront .theme-screenshot',
-				)
+					'stat'        => '1-click-try-sf',
+				),
 			);
 
 			// Determine what the next step should be
@@ -155,13 +157,15 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			$steps[] = array(
 				'message'     => sprintf( $stepMessage, $logoBullet ),
-				'buttonText' => $needsLogo ? __( 'Add a logo', 'storefront' ) : __( 'Add menu items', 'storefront' ),
+				'buttonText'  => $needsLogo ? __( 'Add a logo', 'storefront' ) : __( 'Add menu items', 'storefront' ),
 				'section'     => '#accordion-section-themes',
-				'altStep'    => array(
+				'stat'        => $needsLogo ? '2-add-logo' : '2-add-menu',
+				'altStep'     => array(
 					'buttonText' => __( 'I\'ll figure it out for myself', 'storefront' ),
 					'className'   => 'sf-button-secondary',
 					'action'      => 'exit',
-				)
+					'stat'        => '2-click-exit',
+				),
 			);
 
 			if ( $needsLogo ) {
@@ -171,6 +175,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 					'message'     => __( '<p>Click the \'Select Logo\' button to upload your logo. After you upload your logo, click next to update your menus.</p>', 'storefront' ),
 					'buttonText'  => __( 'Next', 'storefront' ),
 					'section'     => 'title_tagline',
+					'stat'        => '3-select-logo'
 				);
 			}
 
@@ -181,19 +186,23 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'panelSection' => '.control-section-nav_menu',
 				'action'       => 'updateMenus',
 				'showSkip'     => ( bool ) true,
+				'stat'         => '4-add-menu',
 				'childSteps'   => array(
 					array(
 						'message'    => __( '<p>Here are the items currently added to your menu. Click the "Add Items" button.</p>', 'storefront' ),
 						'section'    => '.control-section-nav_menu.open .add-new-menu-item',
+						'stat'       => '4a-menu-items',
 					),
 					array(
 						'message'    => __( '<p>Click on a page to add it to your menu. You can add links to your "shop", "cart", "checkout", and "my account" pages.</p>', 'storefront' ),
 						'section'    => '#available-menu-items-post_type-page',
+						'stat'       => '4b-menu-items-add',
 					),
 					array(
 						'message'    => __( '<p>Add as many pages as you like. When you\'re happy, click "Next" and we\'ll setup your homepage.</p>', 'storefront' ),
 						'section'    => '#available-menu-items-post_type-page',
 						'buttonText' => __( 'Next', 'storefront' ),
+						'stat'       => '4c-next',
 					),
 				)
 			);
@@ -208,6 +217,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 					'action'       => 'resetChildTour',
 					'showSkip'     => ( bool ) true,
 					'suppressHide' => ( bool ) true,
+					'stat'         => '5-static-page',
 				);
 			}
 
@@ -217,12 +227,14 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'action'       => $show_on_front == 'page' ? 'resetChildTour' : 'verifyHomepage',
 				'showSkip'     => ( bool ) true,
 				'suppressHide' => $show_on_front == 'page' ? true : false,
+				'stat'         => '6-set-shop-home',
 			);
 
 			$steps[] = array(
 				'message'      => __( '<p>Awesome! Your shop should be good to go. There\'s lots more to explore in the Customizer but remember to save and publish your changes.</p>', 'storefront' ),
 				'section'      => '#sub-accordion-panel-nav_menus',
 				'showClose'    => 'true',
+				'stat'         => '7-done',
 			);
 
 			return $steps;

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -120,7 +120,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			return array(
 				'autoStartTour' => ( bool ) $show_tour,
 				'showTourAlert' => ( bool ) ! $show_tour,
-				'alertMessage'  => __( 'It looks like your current theme isn\'t ready for shop features yet - your shop and product pages might look a little funny.<br/><br/>We reccomend switching themes to Storefront. <a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">Click here</a> to get started.', 'storefront' ),
+				'alertMessage'  => __( '<strong>Your current theme isn\'t ready for store features yet</strong>. Consequently your shop and product page layouts might display incorrectly.<br/><br/>We reccomend switching themes to <strong>Storefront</strong>. <a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">Click here</a> to get started.', 'storefront' ),
 			);
 		}
 
@@ -134,7 +134,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			$steps[] = array(
 				'title'       => __( 'Customize Your Store', 'storefront' ),
-				'message'     => __( '<p>It looks like your current theme isn\'t ready for shop features yet - your shop pages might look a little funny.</p><p>We suggest switching themes to <b>Storefront</b> which will bring out the best in your shop. Don\'t worry, if you try Storefront now, it won\'t be activated until you save your changes in the Customizer</p>', 'storefront' ),
+				'message'     => __( '<p>Your current theme isn\'t ready for store features yet. Consequently your shop and product page layouts might display incorrectly.</p><p>We recommend switching themes to <strong>Storefront</strong> which will bring out the best in your shop. Don\'t worry, if you try Storefront now, it won\'t be activated until you save your changes in the Customizer</p>', 'storefront' ),
 				'buttonText'  => __( 'I\'ll keep my current theme', 'storefront' ),
 				'section'     => '#customize-info',
 				'className'   => 'sf-button-secondary',

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -116,10 +116,12 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 		public function guided_tour_settings() {
 			$show_tour = isset( $_GET['store-wpcom-nux'] );
 			$theme_supports_woo = current_theme_supports( 'woocommerce' );
+			$supported_themes = wc_get_core_supported_themes();
+			$current_theme = get_template();
 
 			return array(
 				'autoStartTour' => ( bool ) $show_tour,
-				'showTourAlert' => ( bool ) ! $show_tour,
+				'showTourAlert' => ( bool ) ! $theme_supports_woo && ! in_array( $current_theme, $supported_themes ),
 				'alertMessage'  => __( 'It looks like your current theme isn\'t ready for shop features yet - your shop and product pages might look a little funny.<br/><br/>We reccomend switching themes to Storefront. <a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">Click here</a> to get started.', 'storefront' ),
 			);
 		}

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -82,18 +82,18 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 						<h2>{{ data.title }}</h2>
 					<# } #>
 					{{{ data.message }}}
-					<# if ( data.alt_step ) { #>
-						<a class="sf-nux-button sf-nux-alt-button {{ data.alt_step.className }}" href="#">
-							{{ data.alt_step.button_text }}
+					<# if ( data.altStep ) { #>
+						<a class="sf-nux-button sf-nux-alt-button {{ data.altStep.className }}" href="#">
+							{{ data.altStep.buttonText }}
 						</a>
 					<# } #>
-					<# if ( data.button_text ) { #>
+					<# if ( data.buttonText ) { #>
 						<a class="sf-nux-button sf-nux-primary-button {{ data.className }}" href="#">
-							{{ data.button_text }}
+							{{ data.buttonText }}
 						</a>
 					<# } #>
 
-					<# if ( data.show_skip ) { #>
+					<# if ( data.showSkip ) { #>
 						<a class="sf-guided-tour-skip" href="#">
 							<?php esc_attr_e( 'Skip this step', 'wc-api-dev' ); ?>
 						</a>
@@ -114,11 +114,11 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			$steps[] = array(
 				'title'       => __( 'Customize Your Store', 'storefront' ),
 				'message'     => __( 'It looks like your current theme isn\'t ready for shop features yet - your shop pages might look a little funny.</p><p>We suggest switching themes to <b>Storefront</b> which will bring out the best in your shop. Don\'t worry, if you try Storefront now, it won\'t be activated until you save your changes in the Customizer', 'storefront' ),
-				'button_text' => __( 'I\'ll keep my current theme', 'storefront' ),
+				'buttonText' => __( 'I\'ll keep my current theme', 'storefront' ),
 				'section'     => '#customize-info',
 				'className'   => 'sf-button-secondary',
-				'alt_step'    => array(
-					'button_text' => __( 'I\'ll try Storefront!', 'storefront' ),
+				'altStep'    => array(
+					'buttonText' => __( 'I\'ll try Storefront!', 'storefront' ),
 					'action'      => 'expandThemes',
 					'message'     => __( 'Click the thumbnail to get started with Storefront', 'storefront' ),
 					'section'     => '#customize-control-theme_storefront .theme-screenshot',
@@ -131,10 +131,10 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			$steps[] = array(
 				'message'     => __( 'Okay! Remember you can switch themes at any time.</p><p>To get your store looking great, let\'s run through some common tasks:</p><ul>' . $logoBullet . '<li>Add Shop pages to your menus</li><li>Set your shope page as the homepage</li></ul><p>', 'storefront' ),
-				'button_text' => $needsLogo ? __( 'Add a logo', 'storefront' ) : __( 'Add menu items', 'storefront' ),
+				'buttonText' => $needsLogo ? __( 'Add a logo', 'storefront' ) : __( 'Add menu items', 'storefront' ),
 				'section'     => '#accordion-section-themes',
-				'alt_step'    => array(
-					'button_text' => __( 'I\'ll figure it out for myself', 'storefront' ),
+				'altStep'    => array(
+					'buttonText' => __( 'I\'ll figure it out for myself', 'storefront' ),
 					'className'   => 'sf-button-secondary',
 					'action'      => 'exit',
 				)
@@ -145,18 +145,28 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 					'title'       => __( 'Add your logo', 'storefront' ),
 					'action'      => 'addLogo',
 					'message'     => __( 'Click the \'Select Logo\' button to upload your logo. After you upload your logo, click next to update your menus.', 'storefront' ),
-					'button_text' => __( 'Next', 'storefront' ),
+					'buttonText' => __( 'Next', 'storefront' ),
 					'section'     => 'title_tagline',
 				);
 			}
 
 			$steps[] = array(
-				'message'     => __( 'Choose a menu to add shop pages to', 'storefront' ),
-				'section'     => '#sub-accordion-panel-nav_menus',
+				'message'      => __( 'Choose a menu to add shop pages to', 'storefront' ),
+				'section'      => '#sub-accordion-panel-nav_menus',
 				'panel'        => 'nav_menus',
 				'panelSection' => '.control-section-nav_menu',
-				'action'      => 'updateMenus',
-				'button_text' => __( 'Next', 'storefront' ),
+				'action'       => 'updateMenus',
+				'showSkip'     => 'true',
+				'childSteps'   => array(
+					array(
+						'message'    => __( 'Here are the items currently added to your menu. Click the "Add Items" button.', 'storefront' ),
+						'section'    => '.add-new-menu-item',
+					),
+					array(
+						'message'    => __( 'Click on a page to add it to your menu. You can add links to your "shop", "cart", "checkout", and "my account" pages.', 'storefront' ),
+						'section'    => '#available-menu-items-post_type-page',
+					),
+				)
 			);
 
 			return $steps;

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			return array(
 				'autoStartTour' => ( bool ) $show_tour,
 				'showTourAlert' => ( bool ) ! $show_tour,
-				'alertMessage'  => __( '<strong>Your current theme isn\'t ready for store features yet</strong>. Consequently your shop and product page layouts might display incorrectly.<br/><br/>We reccomend switching themes to <strong>Storefront</strong>. <a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">Click here</a> to get started.', 'storefront' ),
+				'alertMessage'  => sprintf( __( '%1$sYour current theme isn\'t ready for store features yet%2$s. Consequently your shop and product page layouts might display incorrectly.%3$sWe reccomend switching themes to %1$sStorefront%2$s. %4$sClick here%5$s to get started.%3$s %6$sLearn more about Storefront%5$s', 'storefront' ), '<strong>', '</strong>', '<br><br>', '<a href="/wp-admin/customize.php?theme=storefront&sf_guided_tour=1&sf_tasks=homepage">', '</a>', '<a href="https://woocommerce.com/storefront/" target="_blank">' ),
 			);
 		}
 

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -142,12 +142,22 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			if ( $needsLogo ) {
 				$steps[] = array(
-					'title'   => __( 'Add your logo', 'storefront' ),
-					'button_text' => 'Next',
-					'message' => __( 'Open the Site Identity Panel, then click the \'Select Logo\' button to upload your logo.', 'storefront' ),
-					'section' => 'title_tagline',
+					'title'       => __( 'Add your logo', 'storefront' ),
+					'action'      => 'addLogo',
+					'message'     => __( 'Click the \'Select Logo\' button to upload your logo. After you upload your logo, click next to update your menus.', 'storefront' ),
+					'button_text' => __( 'Next', 'storefront' ),
+					'section'     => 'title_tagline',
 				);
 			}
+
+			$steps[] = array(
+				'message'     => __( 'Choose a menu to add shop pages to', 'storefront' ),
+				'section'     => '#sub-accordion-panel-nav_menus',
+				'panel'        => 'nav_menus',
+				'panelSection' => '.control-section-nav_menu',
+				'action'      => 'updateMenus',
+				'button_text' => __( 'Next', 'storefront' ),
+			);
 
 			return $steps;
 		}

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -3,7 +3,7 @@
  * Customizer Guided Tour Class
  *
  * @author   WooThemes
- * @since    0.8.7
+ * @since    0.8.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,7 +16,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 		/**
 		 * Setup class.
 		 *
-		 * @since 0.8.7
+		 * @since 0.8.8
 		 */
 		public function __construct() {
 			add_action( 'admin_init', array( $this, 'customizer' ) );
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 		/**
 		 * Customizer.
 		 *
-		 * @since 0.8.7
+		 * @since 0.8.8
 		 */
 		public function customizer() {
 			global $pagenow;
@@ -58,27 +58,27 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 		/**
 		 * Customizer enqueues.
 		 *
-		 * @since 0.8.7
+		 * @since 0.8.8
 		 */
 		public function customize_scripts() {
 			global $storefront_version;
 
-			wp_enqueue_style( 'wc-api-dev-guided-tour', WC_API_Dev::$plugin_url . 'assets/css/admin/customizer.css', array(), $storefront_version, 'all' );
+			wp_enqueue_style( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/css/admin/customizer.css', array(), $storefront_version, 'all' );
 
-			wp_enqueue_script( 'wc-api-dev-guided-tour', WC_API_Dev::$plugin_url . 'assets/js/admin/customizer.js', array( 'jquery', 'wp-backbone' ), $storefront_version, true );
+			wp_enqueue_script( 'wc-store-nux-tour', WC_API_Dev::$plugin_url . 'assets/js/admin/customizer.js', array( 'jquery', 'wp-backbone' ), $storefront_version, true );
 
-			wp_localize_script( 'wc-api-dev-guided-tour', '_wpCustomizeWcApiDevGuidedTourSteps', $this->guided_tour_steps() );
-			wp_localize_script( 'wc-api-dev-guided-tour', '_wpCustomizeWcApiDevGuidedSettings', $this->guided_tour_settings() );
+			wp_localize_script( 'wc-store-nux-tour', '_wpStoreNuxTourSteps', $this->guided_tour_steps() );
+			wp_localize_script( 'wc-store-nux-tour', '_wpStoreNuxSettings', $this->guided_tour_settings() );
 		}
 
 		/**
 		 * Template for steps.
 		 *
-		 * @since 0.8.7
+		 * @since 0.8.8
 		 */
 		public function print_templates() {
 			?>
-			<script type="text/html" id="tmpl-wc-api-guided-tour-step">
+			<script type="text/html" id="tmpl-wc-store-tour-step">
 				<div class="sf-guided-tour-step">
 					<a class="sf-guided-tour-close" href="#">
 						<span class="dashicons dashicons-no-alt"></span>

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -78,6 +78,9 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			?>
 			<script type="text/html" id="tmpl-wc-api-guided-tour-step">
 				<div class="sf-guided-tour-step">
+					<a class="sf-guided-tour-close" href="#">
+						<span class="dashicons dashicons-no-alt"></span>
+					</a>
 					<# if ( data.title ) { #>
 						<h2>{{ data.title }}</h2>
 					<# } #>
@@ -114,11 +117,11 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			$steps[] = array(
 				'title'       => __( 'Customize Your Store', 'storefront' ),
 				'message'     => __( 'It looks like your current theme isn\'t ready for shop features yet - your shop pages might look a little funny.</p><p>We suggest switching themes to <b>Storefront</b> which will bring out the best in your shop. Don\'t worry, if you try Storefront now, it won\'t be activated until you save your changes in the Customizer', 'storefront' ),
-				'buttonText' => __( 'I\'ll keep my current theme', 'storefront' ),
+				'buttonText'  => __( 'I\'ll keep my current theme', 'storefront' ),
 				'section'     => '#customize-info',
 				'className'   => 'sf-button-secondary',
-				'altStep'    => array(
-					'buttonText' => __( 'I\'ll try Storefront!', 'storefront' ),
+				'altStep'     => array(
+					'buttonText'  => __( 'I\'ll try Storefront!', 'storefront' ),
 					'action'      => 'expandThemes',
 					'message'     => __( 'Click the thumbnail to get started with Storefront', 'storefront' ),
 					'section'     => '#customize-control-theme_storefront .theme-screenshot',
@@ -130,7 +133,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			$logoBullet = $needsLogo ? __( '<li>Add your logo</li>', 'storefront' ) : '';
 
 			$steps[] = array(
-				'message'     => __( 'Okay! Remember you can switch themes at any time.</p><p>To get your store looking great, let\'s run through some common tasks:</p><ul>' . $logoBullet . '<li>Add Shop pages to your menus</li><li>Set your shope page as the homepage</li></ul><p>', 'storefront' ),
+				'message'     => __( 'Okay! Remember you can switch themes at any time.</p><p>To get your store looking great, let\'s run through some common tasks:</p><ul>' . $logoBullet . '<li>Add Shop pages to your menus</li><li>Set your shop page as the homepage</li></ul><p>', 'storefront' ),
 				'buttonText' => $needsLogo ? __( 'Add a logo', 'storefront' ) : __( 'Add menu items', 'storefront' ),
 				'section'     => '#accordion-section-themes',
 				'altStep'    => array(
@@ -145,7 +148,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 					'title'       => __( 'Add your logo', 'storefront' ),
 					'action'      => 'addLogo',
 					'message'     => __( 'Click the \'Select Logo\' button to upload your logo. After you upload your logo, click next to update your menus.', 'storefront' ),
-					'buttonText' => __( 'Next', 'storefront' ),
+					'buttonText'  => __( 'Next', 'storefront' ),
 					'section'     => 'title_tagline',
 				);
 			}
@@ -166,7 +169,39 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 						'message'    => __( 'Click on a page to add it to your menu. You can add links to your "shop", "cart", "checkout", and "my account" pages.', 'storefront' ),
 						'section'    => '#available-menu-items-post_type-page',
 					),
+					array(
+						'message'    => __( 'Add as many pages as you like. When you\'re happy, click "Next" and we\'ll setup your homepage.', 'storefront' ),
+						'section'    => '#available-menu-items-post_type-page',
+						'buttonText' => __( 'Next', 'storefront' ),
+					),
 				)
+			);
+
+			// See if setting homepage as static page is needed or not.
+			$show_on_front = get_option( 'show_on_front' );
+
+			if ( $show_on_front != 'page' ) {
+				$steps[] = array(
+					'message'      => __( 'If you would like to set your shop page as your homepage select the "A static page" option.', 'storefront' ),
+					'section'      => '#customize-control-show_on_front',
+					'action'       => 'resetChildTour',
+					'showSkip'     => true,
+					'suppressHide' => true,
+				);
+			}
+
+			$steps[] = array(
+				'message'      => __( 'Select which page you\'d like to set as your homepage. If you want your shop to be the focal point of your site then choosing the "Shop" page would be a good choice.', 'storefront' ),
+				'section'      => '#_customize-dropdown-pages-page_on_front',
+				'action'       => $show_on_front == 'page' ? 'resetChildTour' : 'verifyHomepage',
+				'showSkip'     => true,
+				'suppressHide' => $show_on_front == 'page' ? true : false,
+			);
+
+			$steps[] = array(
+				'message'      => __( 'Awesome! Your shop should be good to go. There\'s lots more to explore in the Customizer but remember to save and publish your changes.', 'storefront' ),
+				'section'      => '#sub-accordion-panel-nav_menus',
+				'showClose'    => 'true',
 			);
 
 			return $steps;

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -126,7 +126,7 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 			);
 
 			// Determine what the next step should be
-			$needsLogo = ! has_custom_logo();
+			$needsLogo = ! has_custom_logo() && current_theme_supports( 'custom-logo' );
 			$logoBullet = $needsLogo ? __( '<li>Add your logo</li>', 'storefront' ) : '';
 
 			$steps[] = array(

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -15,6 +15,8 @@ class WC_API_Dev {
 	 */
 	const WC_MIN_VERSION = '3.0.0';
 
+	public static $plugin_url = null;
+
 	/**
 	 * Class Instance.
 	 */
@@ -103,6 +105,9 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-cheque-defaults.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-paypal-defaults.php' );
 		}
+
+		// Classes that are not related to the API.
+		include_once( dirname( __FILE__ ) . '/inc/class-customizer-guided-tour.php' );
 	}
 
 	/**
@@ -159,6 +164,7 @@ class WC_API_Dev {
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
+			self::$plugin_url = plugin_dir_url( __FILE__ );
 			self::$instance = new self();
 		}
 


### PR DESCRIPTION
This PR is for https://github.com/Automattic/wp-calypso/issues/17101 and very much still in progress.

__To Test__
- Checkout this branch into your `wp-content/plugins` directory on a local install ( that also has woo core ) - or upload the zip to an atomic site.
- Visit the customizer with the following query arg: `http://myawesometestsite.blog/wp-admin/customize.php?store-wpcom-nux=true`
- Using the flow chart [here](https://camo.githubusercontent.com/98934e49b3860246fb0e601ca2889b07ae9402d9/68747470733a2f2f636c6475702e636f6d2f6234614b7850775576502d3230303078323030302e706e67), test out the various flows ( note not all are finished yet )

__TO DO__
- [x] Add tracks or mc stats

