### PR TITLE
Add allowed redirect hosts.

### DIFF
--- a/hotfixes/wc-api-dev-allowed-redirect-hosts.php
+++ b/hotfixes/wc-api-dev-allowed-redirect-hosts.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Adds WordPress.com, and Calypso localhost to safe redirect whitelist
+ *
+ * @since 0.8.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc_api_dev_add_redirect_hosts( $content ) {
+	$content[] = 'wordpress.com';
+	$content[] = 'calypso.localhost';
+	return $content;
+}
+add_filter( 'allowed_redirect_hosts', 'wc_api_dev_add_redirect_hosts' );

--- a/hotfixes/wc-api-dev-allowed-redirect-hosts.php
+++ b/hotfixes/wc-api-dev-allowed-redirect-hosts.php
@@ -2,7 +2,7 @@
 /**
  * Adds WordPress.com, and Calypso localhost to safe redirect whitelist
  *
- * @since 0.8.7
+ * @since 0.8.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -102,6 +102,7 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-email-order-url.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-cheque-defaults.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-paypal-defaults.php' );
+			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
 		}
 	}
 


### PR DESCRIPTION
From discussion in https://github.com/Automattic/wp-calypso/pull/18378 - this branch adds a hook to `allowed_redirect_hosts` to include WordPress.com and calypso.localhost to allowed redirect domains. I wasn't certain about adding Calypso, but might help out in development of features.