### PR TITLE
Add/mailchimp support

### DIFF
--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -256,7 +256,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function get_newsletter_settings( $request ) {
-		$handler = MailChimp_Woocommerce_Admin::connect()
+		$handler = MailChimp_Woocommerce_Admin::connect();
 		$data    = $handler->getMailChimpLists();
 
 		return rest_ensure_response( $data );

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -107,7 +107,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
 	 */
-	private function permissions_check( $request ) {
+	public function permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
@@ -213,7 +213,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
 		$options                            = get_option( 'mailchimp-woocommerce', array() );
 		$mailchimp_active_tab               = $options['active_tab'];
-	  $data                               = $handler->validate( $parameters );
+		$data                               = $handler->validate( $parameters );
 
 		// if previous active tab was sync then we still want sync
 		// because this call is just an update and not part of setup
@@ -244,31 +244,35 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 		$account_name             = 'n/a';
 		$mailchimp_list_name      = 'n/a';
 
-		if (!empty($last_updated_time)) {
-		    $last_updated_time = mailchimp_date_local( $last_updated_time );
+		if ( ! empty( $last_updated_time ) ) {
+				$last_updated_time = mailchimp_date_local( $last_updated_time );
 		}
 
 		if ( ( $mailchimp_api = mailchimp_get_api() ) && ( $store = $mailchimp_api->getStore( $store_id ) ) ) {
 
-		    $store_syncing = $store->isSyncing();
+			$store_syncing = $store->isSyncing();
 
-		    if ( ( $account_details = $handler->getAccountDetails() ) ) {
-		        $account_name = $account_details['account_name'];
-		    }
+			if ( ( $account_details = $handler->getAccountDetails() ) ) {
+				$account_name = $account_details['account_name'];
+			}
 
-		    try {
-		        $products = $mailchimp_api->products( $store_id, 1, 1 );
-		        $mailchimp_total_products = $products['total_items'];
-		        if ( $mailchimp_total_products > $product_count ) $mailchimp_total_products = $product_count;
-		    } catch (\Exception $e) { $mailchimp_total_products = 0; }
+			try {
+				$products = $mailchimp_api->products( $store_id, 1, 1 );
+				$mailchimp_total_products = $products['total_items'];
+				if ( $mailchimp_total_products > $product_count ) {
+					$mailchimp_total_products = $product_count;
+				}
+			} catch (\Exception $e) { $mailchimp_total_products = 0; }
 
-		    try {
-		        $orders = $mailchimp_api->orders( $store_id, 1, 1 );
-		        $mailchimp_total_orders = $orders['total_items'];
-		        if ( $mailchimp_total_orders > $order_count ) $mailchimp_total_orders = $order_count;
-		    } catch (\Exception $e) { $mailchimp_total_orders = 0; }
+			try {
+				$orders = $mailchimp_api->orders( $store_id, 1, 1 );
+				$mailchimp_total_orders = $orders['total_items'];
+				if ( $mailchimp_total_orders > $order_count ) {
+					$mailchimp_total_orders = $order_count;
+				}
+			} catch (\Exception $e) { $mailchimp_total_orders = 0; }
 
-		    $mailchimp_list_name = $handler->getListName();
+			$mailchimp_list_name = $handler->getListName();
 		}
 
 		$data = array();
@@ -277,7 +281,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 		$data['store_syncing']            = $store_syncing;
 		$data['mailchimp_total_products'] = $mailchimp_total_products;
 		$data['product_count']            = $product_count;
- 		$data['mailchimp_total_orders']   = $mailchimp_total_orders;
+		$data['mailchimp_total_orders']   = $mailchimp_total_orders;
 		$data['order_count']              = $order_count;
 		$data['account_name']             = $account_name;
 		$data['mailchimp_list_name']      = $mailchimp_list_name;

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -6,8 +6,6 @@
  *
  * @author   Automattic
  * @category API
- * @package  WooCommerce/API
- * @since    3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -57,7 +55,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 				'callback'            => array( $this, 'update_api_key' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 			),
-		'schema' => array( $this, 'get_api_key_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/store_info', array(
 			array(
@@ -112,8 +109,8 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 	 *
 	 */
 	public function get_settings( $request ) {
-		$options = get_option('mailchimp-woocommerce', array() );
-		$options['mailchimp_active_tab'] = isset($options['mailchimp_active_tab']) ? $options['mailchimp_active_tab'] : "api_key";
+		$options = get_option( 'mailchimp-woocommerce', array() );
+		$options['mailchimp_active_tab'] = isset( $options['mailchimp_active_tab'] ) ? $options['mailchimp_active_tab'] : 'api_key';
 		return rest_ensure_response( $options );
 	}
 
@@ -130,7 +127,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
 		$data                               = $handler->validate( $parameters );
 
-		update_option('mailchimp-woocommerce', $data);
+		update_option( 'mailchimp-woocommerce', $data );
 
 		return rest_ensure_response( $data );
 	}
@@ -148,7 +145,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
 		$data                               = $handler->validate( $parameters );
 
-		update_option('mailchimp-woocommerce', $data);
+		update_option( 'mailchimp-woocommerce', $data );
 
 		return rest_ensure_response( $data );
 	}
@@ -169,7 +166,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
 		$data                               = $handler->validate( $parameters );
 
-		update_option('mailchimp-woocommerce', $data);
+		update_option( 'mailchimp-woocommerce', $data );
 
 		return rest_ensure_response( $data );
 	}
@@ -200,7 +197,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'newsletter_settings';
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
-		$options                            = get_option('mailchimp-woocommerce', array());
+		$options                            = get_option( 'mailchimp-woocommerce', array() );
 		$mailchimp_active_tab               = $options['active_tab'];
 	  $data                               = $handler->validate( $parameters );
 
@@ -210,7 +207,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			$data['mailchimp_active_tab'] = 'sync';
 		}
 
-		update_option('mailchimp-woocommerce', $data);
+		update_option( 'mailchimp-woocommerce', $data);
 
 		return rest_ensure_response( $data );
 	}
@@ -229,32 +226,32 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		$product_count            = mailchimp_get_product_count();
 		$order_count              = mailchimp_get_order_count();
 		$store_syncing            = false;
-		$last_updated_time        = get_option('mailchimp-woocommerce-resource-last-updated');
+		$last_updated_time        = get_option( 'mailchimp-woocommerce-resource-last-updated' );
 		$account_name             = 'n/a';
 		$mailchimp_list_name      = 'n/a';
 
 		if (!empty($last_updated_time)) {
-		    $last_updated_time = mailchimp_date_local($last_updated_time);
+		    $last_updated_time = mailchimp_date_local( $last_updated_time );
 		}
 
-		if (($mailchimp_api = mailchimp_get_api()) && ($store = $mailchimp_api->getStore($store_id))) {
+		if ( ( $mailchimp_api = mailchimp_get_api() ) && ( $store = $mailchimp_api->getStore( $store_id ) ) ) {
 
 		    $store_syncing = $store->isSyncing();
 
-		    if (($account_details = $handler->getAccountDetails())) {
+		    if ( ( $account_details = $handler->getAccountDetails() ) ) {
 		        $account_name = $account_details['account_name'];
 		    }
 
 		    try {
-		        $products = $mailchimp_api->products($store_id, 1, 1);
+		        $products = $mailchimp_api->products( $store_id, 1, 1 );
 		        $mailchimp_total_products = $products['total_items'];
-		        if ($mailchimp_total_products > $product_count) $mailchimp_total_products = $product_count;
+		        if ( $mailchimp_total_products > $product_count ) $mailchimp_total_products = $product_count;
 		    } catch (\Exception $e) { $mailchimp_total_products = 0; }
 
 		    try {
-		        $orders = $mailchimp_api->orders($store_id, 1, 1);
+		        $orders = $mailchimp_api->orders( $store_id, 1, 1 );
 		        $mailchimp_total_orders = $orders['total_items'];
-		        if ($mailchimp_total_orders > $order_count) $mailchimp_total_orders = $order_count;
+		        if ( $mailchimp_total_orders > $order_count ) $mailchimp_total_orders = $order_count;
 		    } catch (\Exception $e) { $mailchimp_total_orders = 0; }
 
 		    $mailchimp_list_name = $handler->getListName();
@@ -262,15 +259,15 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 
 		$data = array();
 
-		$data[ 'last_updated_time' ]        = $last_updated_time->format('D, M j, Y g:i A');
-		$data[ 'store_syncing' ]            = $store_syncing;
-		$data[ 'mailchimp_total_products' ] = $mailchimp_total_products;
-		$data[ 'product_count' ]            = $product_count;
- 		$data[ 'mailchimp_total_orders' ]   = $mailchimp_total_orders;
-		$data[ 'order_count' ]              = $order_count;
-		$data[ 'account_name' ]             = $account_name;
-		$data[ 'mailchimp_list_name' ]      = $mailchimp_list_name;
-		$data[ 'store_id' ]                 = $store_id;
+		$data['last_updated_time']        = $last_updated_time->format( 'D, M j, Y g:i A' );
+		$data['store_syncing']            = $store_syncing;
+		$data['mailchimp_total_products'] = $mailchimp_total_products;
+		$data['product_count']            = $product_count;
+ 		$data['mailchimp_total_orders']   = $mailchimp_total_orders;
+		$data['order_count']              = $order_count;
+		$data['account_name']             = $account_name;
+		$data['mailchimp_list_name']      = $mailchimp_list_name;
+		$data['store_id']                 = $store_id;
 
 		return rest_ensure_response( $data );
 	}

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -130,6 +130,14 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/sync', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'resync' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		//'schema' => array( $this, 'get_api_key_schema' ),
+		) );
 	}
 
 	/**
@@ -299,6 +307,8 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		return rest_ensure_response( $merged_options );
 	}
 
+
+
 	public function get_sync_status( $request ) {
 		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
 		$mailchimp_total_products = $mailchimp_total_orders = 0;
@@ -351,6 +361,14 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 
 
 		return rest_ensure_response( $data );
+	}
+
+	public function resync( $request ) {
+		$input = array();
+		$input['mailchimp_active_tab'] = 'sync';
+		$handler = MailChimp_Woocommerce_Params_Checker::connect();
+		$handler->validate( $input );
+		return $this->get_sync_status( $request );
 	}
 
 	/**

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -244,10 +244,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 		$account_name             = 'n/a';
 		$mailchimp_list_name      = 'n/a';
 
-		if ( ! empty( $last_updated_time ) ) {
-				$last_updated_time = mailchimp_date_local( $last_updated_time );
-		}
-
 		if ( ( $mailchimp_api = mailchimp_get_api() ) && ( $store = $mailchimp_api->getStore( $store_id ) ) ) {
 
 			$store_syncing = $store->isSyncing();
@@ -277,7 +273,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 
 		$data = array();
 
-		$data['last_updated_time']        = $last_updated_time->format( 'D, M j, Y g:i A' );
+		$data['last_updated_time']        = wc_rest_prepare_date_response( $last_updated_time, false );
 		$data['store_syncing']            = $store_syncing;
 		$data['mailchimp_total_products'] = $mailchimp_total_products;
 		$data['product_count']            = $product_count;

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -107,8 +107,9 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 	/**
 	 * Get current MailChimp settings.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @param WP_REST_Request
 	 * @return WP_REST_Response
+	 *
 	 */
 	public function get_settings( $request ) {
 		$options = get_option('mailchimp-woocommerce', array() );
@@ -116,6 +117,13 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $options );
 	}
 
+	/**
+	 * Set MailChimp API key
+	 *
+	 * @param WP_REST_Request, MailChimp API key
+	 * @return WP_REST_Response, updated MailChimp settings
+	 *
+	 */
 	public function update_api_key( $request ) {
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'api_key';
@@ -127,6 +135,13 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Update merchants store information
+	 *
+	 * @param WP_REST_Request, store information
+	 * @return WP_REST_Response, updated MailChimp settings
+	 *
+	 */
 	public function update_store_info( $request ) {
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'store_info';
@@ -138,6 +153,16 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+
+	/**
+	 * Update campaign defaluts settings
+	 * this route we will be able to remove in future as it represent
+	 * potentialy not needed step during MailChimp setup
+	 *
+	 * @param WP_REST_Request, campaign information
+	 * @return WP_REST_Response, updated MailChimp settings
+	 *
+	 */
 	public function update_campaign_defaults( $request ) {
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'campaign_defaults';
@@ -149,6 +174,14 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+
+	/**
+	 * Get current newsletter settings
+	 *
+	 * @param WP_REST_Request,
+	 * @return WP_REST_Response, list of newsletters
+	 *
+	 */
 	public function get_newsletter_settings( $request ) {
 		$handler = MailChimp_Woocommerce_Admin::connect();
 		$data    = $handler->getMailChimpLists();
@@ -156,6 +189,13 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Update newsletter settings
+	 *
+	 * @param WP_REST_Request, newsletter settings
+	 * @return WP_REST_Response, updated MailChimp settings
+	 *
+	 */
 	public function update_newsletter_settings( $request ) {
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'newsletter_settings';
@@ -175,6 +215,13 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Synchronization status between MailChimp plugin and Mailchimp
+	 *
+	 * @param WP_REST_Request,
+	 * @return WP_REST_Response, synchronization status
+	 *
+	 */
 	public function get_sync_status( $request ) {
 		$handler                  = MailChimp_Woocommerce_Admin::connect();
 		$mailchimp_total_products = $mailchimp_total_orders = 0;
@@ -228,6 +275,14 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
+
+	/**
+	 * Force resynchronization
+	 *
+	 * @param WP_REST_Request,
+	 * @return WP_REST_Response, Synchronization status
+	 *
+	 */
 	public function resync( $request ) {
 		$input                         = array();
 		$input['mailchimp_active_tab'] = 'sync';

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -30,7 +30,7 @@ class MailChimp_Woocommerce_Params_Checker extends MailChimp_Woocommerce_Admin {
 	}
 
 	public function validateApiKey( $params ) {
-		return this->validatePostApiKey( $params );
+		return $this->validatePostApiKey( $params );
 	}
 
 	public function validateStoreInfo( $params ) {

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -95,6 +95,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_sync_status' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -56,7 +56,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_api_key' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		'schema' => array( $this, 'get_api_key_schema' ),
 		) );
@@ -65,7 +64,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_store_info' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		'schema' => array( $this, 'get_store_info_schema' ),
 		) );
@@ -74,27 +72,21 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_campaign_defaults' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
-		//'schema' => array( $this, 'get_store_info_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_newsletter_settings' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
-		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_newsletter_settings' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
-		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/sync', array(
 			array(
@@ -102,37 +94,21 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 				'callback'            => array( $this, 'get_sync_status' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 			),
-		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/sync', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'resync' ),
 				'permission_callback' => array( $this, 'update_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
-		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );
-	}
-
-	/**
-	 * Check whether a given request has permission to view payment gateways.
-	 *
-	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|boolean
-	 */
-	public function get_items_permissions_check( $request ) {
-		// if ( ! wc_rest_check_manager_permissions( 'payment_gateways', 'read' ) ) {
-		// 	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
-		// }
-		return true;
 	}
 
 	/**
 	 * Get current MailChimp settings.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_REST_Response
 	 */
 	public function get_settings( $request ) {
 		$options = get_option('mailchimp-woocommerce', array() );
@@ -151,28 +127,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		return rest_ensure_response( $data );
 	}
 
-	/**
-	 * Get the MailChimp api key schema, conforming to JSON Schema.
-	 *
-	 * @return array
-	 */
-	public function get_api_key_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'store_settings',
-			'type'       => 'object',
-			'properties' => array(
-				'api_key' => array(
-					'description' => __( 'MailChimp api key.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-			),
-		);
-
-		return $this->add_additional_fields_schema( $schema );
-	}
-
 	public function update_store_info( $request ) {
 		$parameters                         = $request->get_params();
 		$parameters['mailchimp_active_tab'] = 'store_info';
@@ -182,73 +136,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 		update_option('mailchimp-woocommerce', $data);
 
 		return rest_ensure_response( $data );
-	}
-
-	/**
-	 * Get the payment gateway schema, conforming to JSON Schema.
-	 *
-	 * @return array
-	 */
-	public function get_store_info_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'store_info',
-			'type'       => 'object',
-			'properties' => array(
-				'store_name' => array(
-					'description' => __( 'Store name.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_street' => array(
-					'description' => __( 'Store street.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_city' => array(
-					'description' => __( 'Store city.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_state' => array(
-					'description' => __( 'Store state.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_postal_code' => array(
-					'description' => __( 'Store postal code.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_country' => array(
-					'description' => __( 'Store country.', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_phone' => array(
-					'description' => __( 'Store_phone', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_locale' => array(
-					'description' => __( 'Store locale', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_currency_code' => array(
-					'description' => __( 'Store currency code', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-				'store_phone' => array(
-					'description' => __( 'Store phone', 'woocommerce' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-				),
-			),
-		);
-
-		return $this->add_additional_fields_schema( $schema );
 	}
 
 	public function update_campaign_defaults( $request ) {

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -55,6 +55,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_api_key' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		'schema' => array( $this, 'get_api_key_schema' ),
@@ -63,6 +64,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_store_info' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		'schema' => array( $this, 'get_store_info_schema' ),
@@ -71,6 +73,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_campaign_defaults' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		//'schema' => array( $this, 'get_store_info_schema' ),
@@ -79,6 +82,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_newsletter_settings' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),
@@ -87,6 +91,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_newsletter_settings' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),
@@ -103,6 +108,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'resync' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -267,7 +267,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		$parameters['mailchimp_active_tab'] = 'newsletter_settings';
 		$handler                            = MailChimp_Woocommerce_Admin::connect();
 		$options                            = get_option('mailchimp-woocommerce', array());
-		$mailchimp_active_tab               = $options['mailchimp_active_tab'];
+		$mailchimp_active_tab               = $options['active_tab'];
 	  $data                               = $handler->validate( $parameters );
 
 		// if previous active tab was sync then we still want sync
@@ -329,7 +329,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		$data[ 'account_name' ]             = $account_name;
 		$data[ 'mailchimp_list_name' ]      = $mailchimp_list_name;
 		$data[ 'store_id' ]                 = $store_id;
-
 
 		return rest_ensure_response( $data );
 	}

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -14,38 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-#TODO:
-# * permission check
-
-class MailChimp_Woocommerce_Params_Checker extends MailChimp_Woocommerce_Admin {
-
-	/**
-	 * @return MailChimp_Woocommerce_Admin
-	 */
-	public static function connect()
-	{
-		$env = mailchimp_environment_variables();
-
-		return new self('mailchimp-woocommerce', $env->version);
-	}
-
-	public function validateApiKey( $params ) {
-		return $this->validatePostApiKey( $params );
-	}
-
-	public function validateStoreInfo( $params ) {
-		return $this->validatePostStoreInfo( $params );
-	}
-
-	public function validateCampaignDefaults( $params ) {
-		return $this->validatePostCampaignDefaults( $params );
-	}
-
-	public function validateNewsletterSettings( $params ) {
-		return $this->validatePostNewsletterSettings( $params );
-	}
-}
-
 /**
  * @package WooCommerce/API
  */
@@ -166,17 +134,18 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function update_api_key( $request ) {
-		$parameters     = $request->get_params();
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
-		$data           = $handler->validateApiKey( $parameters );
-		$options        = get_option('mailchimp-woocommerce', array());
-    $merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
-		update_option('mailchimp-woocommerce', $merged_options);
-		return rest_ensure_response( $merged_options );
+		$parameters               = $request->get_params();
+		$parameters['active_tab'] = 'api_ke';
+		$handler                  = MailChimp_Woocommerce_Admin::connect();
+		$data                     = $handler->validate( $parameters );
+
+		update_option('mailchimp-woocommerce', $data);
+
+		return rest_ensure_response( $data );
 	}
 
 	/**
-	 * Get the payment gateway schema, conforming to JSON Schema.
+	 * Get the MailChimp api key schema, conforming to JSON Schema.
 	 *
 	 * @return array
 	 */
@@ -197,14 +166,15 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		return $this->add_additional_fields_schema( $schema );
 	}
 
-	public function update_store_info( $request ) {
-		$parameters     = $request->get_params();
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
-		$data           = $handler->validateStoreInfo( $parameters );
-		$options        = get_option('mailchimp-woocommerce', array());
-		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
-		update_option('mailchimp-woocommerce', $merged_options);
-		return rest_ensure_response( $merged_options );
+	public function update_store_info( $request ) {}
+		$parameters               = $request->get_params();
+		$parameters['active_tab'] = 'store_info';
+		$handler                  = MailChimp_Woocommerce_Admin::connect();
+		$data                     = $handler->validate( $parameters );
+
+		update_option('mailchimp-woocommerce', $data);
+
+		return rest_ensure_response( $data );
 	}
 
 	/**
@@ -275,45 +245,46 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function update_campaign_defaults( $request ) {
-		$parameters     = $request->get_params();
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
-		$data           = $handler->validateCampaignDefaults( $parameters );
-		$options        = get_option('mailchimp-woocommerce', array());
-		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
-		update_option('mailchimp-woocommerce', $merged_options);
-		return rest_ensure_response( $merged_options );
+		$parameters               = $request->get_params();
+		$parameters['active_tab'] = 'campaign_defaults';
+		$handler                  = MailChimp_Woocommerce_Admin::connect();
+		$data                     = $handler->validate( $parameters );
+
+		update_option('mailchimp-woocommerce', $data);
+
+		return rest_ensure_response( $data );
 	}
 
 	public function get_newsletter_settings( $request ) {
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
-		$data           = $handler->getMailChimpLists();
+		$handler = MailChimp_Woocommerce_Admin::connect()
+		$data    = $handler->getMailChimpLists();
+
 		return rest_ensure_response( $data );
 	}
 
 	public function update_newsletter_settings( $request ) {
-		$parameters     = $request->get_params();
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
-		$data           = $handler->validateNewsletterSettings( $parameters );
-		$options        = get_option('mailchimp-woocommerce', array());
-		$active_tab     = $options['active_tab'];
-		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+		$parameters               = $request->get_params();
+		$parameters['active_tab'] = 'newsletter_settings';
+		$handler                  = MailChimp_Woocommerce_Admin::connect();
+		$options                  = get_option('mailchimp-woocommerce', array());
+		$active_tab               = $options['active_tab'];
+	  $data                     = $handler->validate( $parameters );
 
 		// if previous active tab was sync then we still want sync
-		// because  this call is just an update and not part of setup
+		// because this call is just an update and not part of setup
 		if( $active_tab == 'sync' ) {
-			$merged_options['active_tab'] = 'sync';
+			$data['active_tab'] = 'sync';
+			update_option('mailchimp-woocommerce', $data);
 		}
-		update_option('mailchimp-woocommerce', $merged_options);
-		return rest_ensure_response( $merged_options );
+
+		return rest_ensure_response( $data );
 	}
 
-
-
 	public function get_sync_status( $request ) {
-		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$handler                  = MailChimp_Woocommerce_Admin::connect();
 		$mailchimp_total_products = $mailchimp_total_orders = 0;
-		$store_id = mailchimp_get_store_id();
-		$product_count = mailchimp_get_product_count();
+		$store_id                 = mailchimp_get_store_id();
+		$product_count            = mailchimp_get_product_count();
 		$order_count = mailchimp_get_order_count();
 		$store_syncing = false;
 		$last_updated_time = get_option('mailchimp-woocommerce-resource-last-updated');
@@ -364,22 +335,13 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function resync( $request ) {
-		$input = array();
+		$input                         = array();
 		$input['mailchimp_active_tab'] = 'sync';
-		$handler = MailChimp_Woocommerce_Params_Checker::connect();
-		$handler->validate( $input );
-		return $this->get_sync_status( $request );
-	}
+		$handler                       = MailChimp_Woocommerce_Admin::connect();
 
-	/**
-	 * Get any query params needed.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		return array(
-			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
-		);
+		$handler->validate( $input );
+
+		return $this->get_sync_status( $request );
 	}
 
 }

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * REST API WC MailChimp settings
+ *
+ * Handles requests that interact with MailChimp plugin.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ * @since    3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+#TODO:
+# * permission check
+
+class MailChimp_Woocommerce_Params_Checker extends MailChimp_Woocommerce_Admin {
+
+	/**
+	 * @return MailChimp_Woocommerce_Admin
+	 */
+	public static function connect()
+	{
+		$env = mailchimp_environment_variables();
+
+		return new self('mailchimp-woocommerce', $env->version);
+	}
+
+	public function validateStoreInfo( $params ) {
+		return $this->validatePostStoreInfo( $params );
+	}
+
+	public function validateCampaignDefaults( $params ) {
+		return $this->validatePostCampaignDefaults( $params );
+	}
+
+	public function validateNewsletterSettings( $params ) {
+		return $this->validatePostNewsletterSettings( $params );
+	}
+}
+
+/**
+ * @package WooCommerce/API
+ */
+class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'mailchimp';
+
+	/**
+	 * MailChimp settings.
+	 *
+	 * @param  WP_REST_Request    $request    Request object.
+	 * @return WP_REST_Response   $response   Response data.
+	 */
+
+	/**
+	 * Register MailChimp settings routes
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_settings' ),
+			)
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/api_key', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_api_key' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		'schema' => array( $this, 'get_api_key_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/store_info', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_store_info' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		'schema' => array( $this, 'get_store_info_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/campaign_defaults', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_campaign_defaults' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		//'schema' => array( $this, 'get_store_info_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_newsletter_settings' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		//'schema' => array( $this, 'get_api_key_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_newsletter_settings' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+		//'schema' => array( $this, 'get_api_key_schema' ),
+		) );
+	}
+
+	/**
+	 * Check whether a given request has permission to view payment gateways.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		// if ( ! wc_rest_check_manager_permissions( 'payment_gateways', 'read' ) ) {
+		// 	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		// }
+		return true;
+	}
+
+	/**
+	 * Get payment gateways.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_settings( $request ) {
+		$options = get_option('mailchimp-woocommerce', array() );
+		$options['active_tab'] = isset($options['active_tab']) ? $options['active_tab'] : "api_key";
+		return rest_ensure_response( $options );
+	}
+
+	public function update_api_key( $request ) {
+		$parameters     = $request->get_params();
+		$handler        = MailChimp_Woocommerce_Admin::connect();
+		$data           = $handler->validatePostApiKey( $parameters );
+		$options        = get_option('mailchimp-woocommerce', array());
+    $merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+		update_option('mailchimp-woocommerce', $merged_options);
+		return rest_ensure_response( $merged_options );
+	}
+
+	/**
+	 * Get the payment gateway schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_api_key_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'store_settings',
+			'type'       => 'object',
+			'properties' => array(
+				'api_key' => array(
+					'description' => __( 'MailChimp api key.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	public function update_store_info( $request ) {
+		$parameters     = $request->get_params();
+		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$data           = $handler->validateStoreInfo( $parameters );
+		$options        = get_option('mailchimp-woocommerce', array());
+		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+		update_option('mailchimp-woocommerce', $merged_options);
+		return rest_ensure_response( $merged_options );
+	}
+
+	/**
+	 * Get the payment gateway schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_store_info_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'store_info',
+			'type'       => 'object',
+			'properties' => array(
+				'store_name' => array(
+					'description' => __( 'Store name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_street' => array(
+					'description' => __( 'Store street.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_city' => array(
+					'description' => __( 'Store city.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_state' => array(
+					'description' => __( 'Store state.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_postal_code' => array(
+					'description' => __( 'Store postal code.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_country' => array(
+					'description' => __( 'Store country.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_phone' => array(
+					'description' => __( 'Store_phone', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_locale' => array(
+					'description' => __( 'Store locale', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_currency_code' => array(
+					'description' => __( 'Store currency code', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'store_phone' => array(
+					'description' => __( 'Store phone', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	public function update_campaign_defaults( $request ) {
+		$parameters     = $request->get_params();
+		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$data           = $handler->validateCampaignDefaults( $parameters );
+		$options        = get_option('mailchimp-woocommerce', array());
+		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+		update_option('mailchimp-woocommerce', $merged_options);
+		return rest_ensure_response( $merged_options );
+	}
+
+	public function get_newsletter_settings( $request ) {
+		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$data           = $handler->getMailChimpLists();
+		return rest_ensure_response( $data );
+	}
+
+	public function update_newsletter_settings( $request ) {
+		$parameters     = $request->get_params();
+		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$data           = $handler->validateNewsletterSettings( $parameters );
+		$options        = get_option('mailchimp-woocommerce', array());
+		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+		update_option('mailchimp-woocommerce', $merged_options);
+		return rest_ensure_response( $merged_options );
+	}
+
+	/**
+	 * Get any query params needed.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
+	}
+
+}

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -146,7 +146,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	/**
-	 * Get payment gateways.
+	 * Get current MailChimp settings.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
@@ -287,7 +287,14 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
 		$data           = $handler->validateNewsletterSettings( $parameters );
 		$options        = get_option('mailchimp-woocommerce', array());
+		$active_tab     = $options['active_tab'];
 		$merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
+
+		// if previous active tab was sync then we still want sync
+		// because  this call is just an update and not part of setup
+		if( $active_tab == 'sync' ) {
+			$merged_options['active_tab'] = 'sync';
+		}
 		update_option('mailchimp-woocommerce', $merged_options);
 		return rest_ensure_response( $merged_options );
 	}

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -166,7 +166,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		return $this->add_additional_fields_schema( $schema );
 	}
 
-	public function update_store_info( $request ) {}
+	public function update_store_info( $request ) {
 		$parameters               = $request->get_params();
 		$parameters['active_tab'] = 'store_info';
 		$handler                  = MailChimp_Woocommerce_Admin::connect();

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @package WooCommerce/API
  */
-class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Controller {
+class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -48,7 +48,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_settings' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 			)
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/api_key', array(
@@ -95,7 +95,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_sync_status' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),
 		) );

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -274,8 +274,9 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		// because this call is just an update and not part of setup
 		if( $mailchimp_active_tab == 'sync' ) {
 			$data['mailchimp_active_tab'] = 'sync';
-			update_option('mailchimp-woocommerce', $data);
 		}
+
+		update_option('mailchimp-woocommerce', $data);
 
 		return rest_ensure_response( $data );
 	}

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -48,6 +48,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_settings' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			)
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/api_key', array(
@@ -94,7 +95,6 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_sync_status' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			),
 		//'schema' => array( $this, 'get_api_key_schema' ),

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -129,15 +129,15 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	 */
 	public function get_settings( $request ) {
 		$options = get_option('mailchimp-woocommerce', array() );
-		$options['active_tab'] = isset($options['active_tab']) ? $options['active_tab'] : "api_key";
+		$options['mailchimp_active_tab'] = isset($options['mailchimp_active_tab']) ? $options['mailchimp_active_tab'] : "api_key";
 		return rest_ensure_response( $options );
 	}
 
 	public function update_api_key( $request ) {
-		$parameters               = $request->get_params();
-		$parameters['active_tab'] = 'api_key';
-		$handler                  = MailChimp_Woocommerce_Admin::connect();
-		$data                     = $handler->validate( $parameters );
+		$parameters                         = $request->get_params();
+		$parameters['mailchimp_active_tab'] = 'api_key';
+		$handler                            = MailChimp_Woocommerce_Admin::connect();
+		$data                               = $handler->validate( $parameters );
 
 		update_option('mailchimp-woocommerce', $data);
 
@@ -167,10 +167,10 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function update_store_info( $request ) {
-		$parameters               = $request->get_params();
-		$parameters['active_tab'] = 'store_info';
-		$handler                  = MailChimp_Woocommerce_Admin::connect();
-		$data                     = $handler->validate( $parameters );
+		$parameters                         = $request->get_params();
+		$parameters['mailchimp_active_tab'] = 'store_info';
+		$handler                            = MailChimp_Woocommerce_Admin::connect();
+		$data                               = $handler->validate( $parameters );
 
 		update_option('mailchimp-woocommerce', $data);
 
@@ -245,10 +245,10 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function update_campaign_defaults( $request ) {
-		$parameters               = $request->get_params();
-		$parameters['active_tab'] = 'campaign_defaults';
-		$handler                  = MailChimp_Woocommerce_Admin::connect();
-		$data                     = $handler->validate( $parameters );
+		$parameters                         = $request->get_params();
+		$parameters['mailchimp_active_tab'] = 'campaign_defaults';
+		$handler                            = MailChimp_Woocommerce_Admin::connect();
+		$data                               = $handler->validate( $parameters );
 
 		update_option('mailchimp-woocommerce', $data);
 
@@ -263,17 +263,17 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 	}
 
 	public function update_newsletter_settings( $request ) {
-		$parameters               = $request->get_params();
-		$parameters['active_tab'] = 'newsletter_settings';
-		$handler                  = MailChimp_Woocommerce_Admin::connect();
-		$options                  = get_option('mailchimp-woocommerce', array());
-		$active_tab               = $options['active_tab'];
-	  $data                     = $handler->validate( $parameters );
+		$parameters                         = $request->get_params();
+		$parameters['mailchimp_active_tab'] = 'newsletter_settings';
+		$handler                            = MailChimp_Woocommerce_Admin::connect();
+		$options                            = get_option('mailchimp-woocommerce', array());
+		$mailchimp_active_tab               = $options['mailchimp_active_tab'];
+	  $data                               = $handler->validate( $parameters );
 
 		// if previous active tab was sync then we still want sync
 		// because this call is just an update and not part of setup
-		if( $active_tab == 'sync' ) {
-			$data['active_tab'] = 'sync';
+		if( $mailchimp_active_tab == 'sync' ) {
+			$data['mailchimp_active_tab'] = 'sync';
 			update_option('mailchimp-woocommerce', $data);
 		}
 
@@ -285,11 +285,11 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 		$mailchimp_total_products = $mailchimp_total_orders = 0;
 		$store_id                 = mailchimp_get_store_id();
 		$product_count            = mailchimp_get_product_count();
-		$order_count = mailchimp_get_order_count();
-		$store_syncing = false;
-		$last_updated_time = get_option('mailchimp-woocommerce-resource-last-updated');
-		$account_name = 'n/a';
-		$mailchimp_list_name = 'n/a';
+		$order_count              = mailchimp_get_order_count();
+		$store_syncing            = false;
+		$last_updated_time        = get_option('mailchimp-woocommerce-resource-last-updated');
+		$account_name             = 'n/a';
+		$mailchimp_list_name      = 'n/a';
 
 		if (!empty($last_updated_time)) {
 		    $last_updated_time = mailchimp_date_local($last_updated_time);

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -135,7 +135,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 
 	public function update_api_key( $request ) {
 		$parameters               = $request->get_params();
-		$parameters['active_tab'] = 'api_ke';
+		$parameters['active_tab'] = 'api_key';
 		$handler                  = MailChimp_Woocommerce_Admin::connect();
 		$data                     = $handler->validate( $parameters );
 

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @package WooCommerce/API
  */
-class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Controller {
+class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -46,21 +46,21 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_settings' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			)
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/api_key', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_api_key' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/store_info', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_store_info' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		'schema' => array( $this, 'get_store_info_schema' ),
 		) );
@@ -68,37 +68,51 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_campaign_defaults' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_newsletter_settings' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/newsletter_setting', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_newsletter_settings' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/sync', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_sync_status' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/sync', array(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'resync' ),
-				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
 			),
 		) );
+	}
+
+	/**
+	 * Makes sure the current user has access to WRITE the settings APIs.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	private function permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
 	}
 
 	/**
@@ -203,7 +217,7 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Dev_Settings_Con
 
 		// if previous active tab was sync then we still want sync
 		// because this call is just an update and not part of setup
-		if( $mailchimp_active_tab == 'sync' ) {
+		if( 'sync' === $mailchimp_active_tab  ) {
 			$data['mailchimp_active_tab'] = 'sync';
 		}
 

--- a/api/class-wc-rest-dev-mailchimp-settings-controller.php
+++ b/api/class-wc-rest-dev-mailchimp-settings-controller.php
@@ -29,6 +29,10 @@ class MailChimp_Woocommerce_Params_Checker extends MailChimp_Woocommerce_Admin {
 		return new self('mailchimp-woocommerce', $env->version);
 	}
 
+	public function validateApiKey( $params ) {
+		return this->validatePostApiKey( $params );
+	}
+
 	public function validateStoreInfo( $params ) {
 		return $this->validatePostStoreInfo( $params );
 	}
@@ -147,8 +151,8 @@ class WC_REST_Dev_MailChimp_Settings_Controller extends WC_REST_Settings_Control
 
 	public function update_api_key( $request ) {
 		$parameters     = $request->get_params();
-		$handler        = MailChimp_Woocommerce_Admin::connect();
-		$data           = $handler->validatePostApiKey( $parameters );
+		$handler        = MailChimp_Woocommerce_Params_Checker::connect();
+		$data           = $handler->validateApiKey( $parameters );
 		$options        = get_option('mailchimp-woocommerce', array());
     $merged_options = (isset($data) && is_array($data)) ? array_merge($options, $data) : $options;
 		update_option('mailchimp-woocommerce', $merged_options);

--- a/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
+++ b/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
@@ -13,6 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 //TODO:
 //  - use this function to capture messages and feed them back to Calypso on return from API.
 
-if ( ! function_exists( 'add_settings_error' ) && ! is_admin() ) {
+if ( ! function_exists( 'add_settings_error' ) && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
         function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
 }

--- a/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
+++ b/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * add_settings_error is only available in UI contecext
+ * adding a mock version to prevent API failures
+ *
+ * @since 0.8.8
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+//TODO:
+//  - use this function to capture messages and feed them back to Calypso on return from API.
+
+if ( ! function_exists( 'add_settings_error' ) ) {
+        function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
+}

--- a/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
+++ b/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
@@ -13,6 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 //TODO:
 //  - use this function to capture messages and feed them back to Calypso on return from API.
 
+// Parts of the MailChimp plugin reused for REST response purpose are signaling to the user via UI
+// that the information he has provided are not correct - this happens for example when some fields
+// are missing in the form user should fill in. It is done via add_settings_error.
+// This function is part of UI and within REST rest_api_ini it is not available - which makes sense
+// because REST has nothing to do with UI. Missing function was causing fata errors.
+// Loading template.php is not an option bacause it would significantly slow down the response.
+// The solution is to have dummy add_settings_error available only in REST context
+
 if ( ! function_exists( 'add_settings_error' ) && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-        function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
+	function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
 }

--- a/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
+++ b/hotfixes/wc-api-dev-mailchimp-add-settings-error.php
@@ -13,6 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 //TODO:
 //  - use this function to capture messages and feed them back to Calypso on return from API.
 
-if ( ! function_exists( 'add_settings_error' ) ) {
+if ( ! function_exists( 'add_settings_error' ) && ! is_admin() ) {
         function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
 }

--- a/hotfixes/wc-api-dev-mailchimp-no-redirect.php
+++ b/hotfixes/wc-api-dev-mailchimp-no-redirect.php
@@ -9,7 +9,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-function wc_api_dev_mailchimp_no_redirect() {
-	add_option('mailchimp_woocommerce_plugin_do_activation_redirect', false);
-}
-add_action( 'admin_init', 'wc_api_dev_mailchimp_no_redirect' );
+add_filter( 'option_mailchimp_woocommerce_plugin_do_activation_redirect', __returne_false );

--- a/hotfixes/wc-api-dev-mailchimp-no-redirect.php
+++ b/hotfixes/wc-api-dev-mailchimp-no-redirect.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Prevent redirection during MailChimp activation.
+ *
+ * @since 0.8.8
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc_api_dev_mailchimp_no_redirect() {
+	add_option('mailchimp_woocommerce_plugin_do_activation_redirect', false);
+}
+add_action( 'admin_init', 'wc_api_dev_mailchimp_no_redirect' );

--- a/hotfixes/wc-api-dev-mailchimp-no-redirect.php
+++ b/hotfixes/wc-api-dev-mailchimp-no-redirect.php
@@ -9,4 +9,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_filter( 'option_mailchimp_woocommerce_plugin_do_activation_redirect', __returne_false );
+add_filter( 'option_mailchimp_woocommerce_plugin_do_activation_redirect', '__return_false' );

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -115,7 +115,6 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-masterbar-menu.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-no-redirect.php' );
-			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-add-settings-error.php' );
 		}
 
 		// Classes that are not related to the API.
@@ -173,6 +172,9 @@ class WC_API_Dev {
 			$this->$controller = new $controller();
 			$this->$controller->register_routes();
 		}
+
+		// We include it here because rest_api_init is a proper context for mocekd add_settings_error function
+		include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-add-settings-error.php' );		
 	}
 
 	/**

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -115,6 +115,7 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-masterbar-menu.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-no-redirect.php' );
+			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-add-settings-error.php' );
 		}
 
 		// Classes that are not related to the API.

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -101,6 +101,8 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-shipping-methods-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-payment-gateways-controller.php' );
 
+
+		// This is only for Calypso/Store. Do not merge into core.
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
 				include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-mailchimp-settings-controller.php' );
 		}
@@ -173,8 +175,8 @@ class WC_API_Dev {
 			$this->$controller->register_routes();
 		}
 
-		// We include it here because rest_api_init is a proper context for mocekd add_settings_error function
-		include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-add-settings-error.php' );		
+		// We include it here because rest_api_init is a proper context for mocked add_settings_error function
+		include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-add-settings-error.php' );
 	}
 
 	/**

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -110,6 +110,7 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-paypal-defaults.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-masterbar-menu.php' );
+			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-no-redirect.php' );
 		}
 
 		// Classes that are not related to the API.

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -73,6 +73,7 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-continents-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-countries-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-currencies-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-mailchimp-settings-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-orders-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-order-notes-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-order-refunds-controller.php' );
@@ -131,6 +132,7 @@ class WC_API_Dev {
 			'WC_REST_Dev_Data_Continents_Controller',
 			'WC_REST_Dev_Data_Countries_Controller',
 			'WC_REST_Dev_Data_Currencies_Controller',
+			'WC_REST_Dev_MailChimp_Settings_Controller',
 			'WC_REST_Dev_Order_Notes_Controller',
 			'WC_REST_Dev_Order_Refunds_Controller',
 			'WC_REST_Dev_Orders_Controller',

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -73,7 +73,6 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-continents-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-countries-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-data-currencies-controller.php' );
-		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-mailchimp-settings-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-orders-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-order-notes-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-order-refunds-controller.php' );
@@ -101,6 +100,10 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-system-status-tools-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-shipping-methods-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-payment-gateways-controller.php' );
+
+		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
+				include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-mailchimp-settings-controller.php' );
+		}
 
 		// Things that aren't related to a specific endpoint but to things like cross-plugin compatibility
 		if ( defined( 'WC_API_DEV_ENABLE_HOTFIXES' ) && true === WC_API_DEV_ENABLE_HOTFIXES ) {
@@ -132,7 +135,6 @@ class WC_API_Dev {
 			'WC_REST_Dev_Data_Continents_Controller',
 			'WC_REST_Dev_Data_Countries_Controller',
 			'WC_REST_Dev_Data_Currencies_Controller',
-			'WC_REST_Dev_MailChimp_Settings_Controller',
 			'WC_REST_Dev_Order_Notes_Controller',
 			'WC_REST_Dev_Order_Refunds_Controller',
 			'WC_REST_Dev_Orders_Controller',
@@ -161,6 +163,10 @@ class WC_API_Dev {
 			'WC_REST_Dev_Shipping_Methods_Controller',
 			'WC_REST_Dev_Payment_Gateways_Controller',
 		);
+
+		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
+				$controllers[] = 'WC_REST_Dev_MailChimp_Settings_Controller';
+		}
 
 		foreach ( $controllers as $controller ) {
 			$this->$controller = new $controller();


### PR DESCRIPTION
### Information
This is REST API implementation needed to support MailChimp on Store project. 
Rest endpoints represent various steps of MailChimp setup

### Testing
This works with https://github.com/Automattic/wp-calypso/pull/17434
Calypso code will install MailChimp plugin on site. This Rest endpoints rely on MailChimp plugin presence in order to work. Going through MailChimp Setup will use all the provided REST endpoints except the resync one. Resync can be activated from The last pannels resync link.

The Calypso part is WIP ( 99% ) and requires only minor UI work. When testing and asked for locale use `en` and set timezone for `New York` 