### PR TITLE
Add Store link to Masterbar

### DIFF
--- a/assets/css/masterbar.css
+++ b/assets/css/masterbar.css
@@ -1,0 +1,5 @@
+#wpadminbar li.menupop > .ab-sub-wrapper li#wp-admin-bar-store {
+	background-image: url( "data:image/svg+xml,%3Csvg%20class%3D%22gridicon%20gridicons-cart%22%20height%3D%2224%22%20width%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cg%3E%3Cpath%20fill%3D%22%2387a6bc%22%20d%3D%22M9%2020c0%201.1-.9%202-2%202s-1.99-.9-1.99-2S5.9%2018%207%2018s2%20.9%202%202zm8-2c-1.1%200-1.99.9-1.99%202s.89%202%201.99%202%202-.9%202-2-.9-2-2-2zm.396-5c.937%200%201.75-.65%201.952-1.566L21%205H7V4c0-1.105-.895-2-2-2H3v2h2v11c0%201.105.895%202%202%202h12c0-1.105-.895-2-2-2H7v-2h10.396z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E" );
+	background-repeat: no-repeat;
+	background-position: 21px 12px;	
+}

--- a/hotfixes/wc-api-dev-masterbar-menu.php
+++ b/hotfixes/wc-api-dev-masterbar-menu.php
@@ -9,6 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+function wc_api_dev_masterbar_css() {
+	wp_enqueue_style( 'wp-api-dev-masterbar', '/wp-content/plugins/wc-api-dev/assets/css/masterbar.css', array(), WC_API_Dev::CURRENT_VERSION );	
+}
+add_action( 'wp_enqueue_scripts', 'wc_api_dev_masterbar_css' );
+add_action( 'admin_enqueue_scripts', 'wc_api_dev_masterbar_css' );
+
 add_action( 'jetpack_masterbar', function() {
 	global $wp_admin_bar;
 
@@ -22,7 +28,8 @@ add_action( 'jetpack_masterbar', function() {
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'blog',
 			'id'     => 'store',
-			'title'  => esc_html__( 'Store', 'jetpack' ),
+			// TODO: translation domain change
+			'title'  => esc_html__( 'Store (BETA)', 'storefront' ),
 			'href'   => $store_url,
 			'meta'   => array(
 				'class' => 'mb-icon-spacer',

--- a/hotfixes/wc-api-dev-masterbar-menu.php
+++ b/hotfixes/wc-api-dev-masterbar-menu.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Adds a Store link to the masterbar
+ *
+ * @since 0.8.8
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'jetpack_masterbar', function() {
+	global $wp_admin_bar;
+
+	if ( isset( $wp_admin_bar ) ) {
+		$strip_http = '/.*?:\/\//i';
+		$site_slug  = preg_replace( $strip_http, '', get_home_url() );
+		$site_slug  = str_replace( '/', '::', $site_slug );
+
+		$store_url = 'https://wordpress.com/store/' . $site_slug;
+
+		$wp_admin_bar->add_menu( array(
+			'parent' => 'blog',
+			'id'     => 'store',
+			'title'  => esc_html__( 'Store', 'jetpack' ),
+			'href'   => $store_url,
+			'meta'   => array(
+				'class' => 'mb-icon-spacer',
+			)
+		) );
+	}
+} );

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -103,6 +103,7 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-cheque-defaults.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-paypal-defaults.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
+			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-masterbar-menu.php' );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/16812

Now that Jetpack 5.4 is launched, this PR utilizes the new `jetpack_masterbar` ( thanks @justinshreve ) to add the Store menu item to the masterbar on the remote store site.

<img width="710" alt="timmy_s_flies_ _come_fly_with_me" src="https://user-images.githubusercontent.com/22080/31191229-5cb1abd0-a8f2-11e7-8d30-df4caf275ee0.png">

__To Test__
- Open up the front-end of a store site while logged in to the associated wpcom account
- Click "My Site(s)" in the masterbar, verify the "Shop (BETA)" link is shown
- Click on the Shop link, verify the calypso store section is opened properly
- Repeat the same steps above but from within `wp-admin` on the store site