### PR TITLE
Masterbar: Only Show Store to users with manage_options

### DIFF
--- a/hotfixes/wc-api-dev-masterbar-menu.php
+++ b/hotfixes/wc-api-dev-masterbar-menu.php
@@ -18,7 +18,7 @@ add_action( 'admin_enqueue_scripts', 'wc_api_dev_masterbar_css' );
 add_action( 'jetpack_masterbar', function() {
 	global $wp_admin_bar;
 
-	if ( isset( $wp_admin_bar ) ) {
+	if ( isset( $wp_admin_bar ) && current_user_can( 'manage_options' ) ) {
 		$strip_http = '/.*?:\/\//i';
 		$site_slug  = preg_replace( $strip_http, '', get_home_url() );
 		$site_slug  = str_replace( '/', '::', $site_slug );


### PR DESCRIPTION
Follow up to #57 - I forgot to add a proper capability check before displaying the Store link in the masterbar. This logic emulates the same capability check we are doing in Calypso for showing the Store link in the sidebar by checking to see that the current user has `manage_options` capability.

__To Test__
- Login as a non-admin user to a test AT site
- Verify the Store link does not show up in the masterbar
- Login as a user with admin privledges to the same site and verify the Store link is still shown