### PR TITLE
Store on .com: Enable auto data updates

### DIFF
--- a/hotfixes/wc-api-dev-enable-auto-update-db.php
+++ b/hotfixes/wc-api-dev-enable-auto-update-db.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Runs DB updates automatically without wp-admin notices.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/16703
+ * @see https://github.com/woocommerce/woocommerce/pull/16711
+ * @since 0.8.9
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'woocommerce_enable_auto_update_db', '__return_true' );

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -117,6 +117,7 @@ class WC_API_Dev {
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-allowed-redirect-hosts.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-masterbar-menu.php' );
 			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-mailchimp-no-redirect.php' );
+			include_once( dirname( __FILE__ ) . '/hotfixes/wc-api-dev-enable-auto-update-db.php' );
 		}
 
 		// Classes that are not related to the API.


### PR DESCRIPTION
This leverages the filter added in https://github.com/woocommerce/woocommerce/pull/16711, so that we can enable data updates automatically, without our Store users needing to go into wp-admin to click the notice.

Fixes https://github.com/Automattic/wp-calypso/issues/17862.

To Test:
* Install this branch
* Switch your WooCommerce install to an older install. I did `git checkout tags/3.1.2`
* Add a debug line somewhere so that you can monitor the db version and make sure it updates. I added this to the hotfix file above the filter. `error_log( get_option( 'woocommerce_db_version', null ) );`
* Switch your WooCommerce install to 3.2. 
* Visit wp-admin. You should NOT see a notice about db updates. Your debug line should show the db version switched to 3.2.0.
* You can downgrade back to 3.1.2. Now, instead of visting `wp-admin`, make a REST API request. The next request you make after that should show you that the db version correctly switched to 3.2.0.