### PR TITLE
Email settings endpoint.

### DIFF
--- a/api/class-wc-rest-dev-settings-email-controller.php
+++ b/api/class-wc-rest-dev-settings-email-controller.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * REST API Settings controller
+ *
+ * Handles requests to the /settings/batch_email endpoint.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Settings controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Dev_Settings_Email_Controller extends WC_REST_Settings_Controller {
+
+	/**
+	 * WP REST API namespace/version.
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Register routes.
+	 *
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/batch_email', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_all_email_settings' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+		) );
+	}
+
+	/**
+	 * Bulk read email setings;
+	 *
+	 * @return array Of WP_Error or WP_REST_Response.
+	 */
+	public function get_all_email_settings() {
+		/** @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+
+		// List of all items returned by the settings/batch_email endpoint.
+		$items = [
+			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_name' ],
+			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_address' ],
+			[ 'group_id' => 'email_new_order',                 'id' => 'enabled' ],
+			[ 'group_id' => 'email_new_order',                 'id' => 'recipient' ],
+			[ 'group_id' => 'email_cancelled_order',           'id' => 'enabled' ],
+			[ 'group_id' => 'email_cancelled_order',           'id' => 'recipient' ],
+			[ 'group_id' => 'email_failed_order',              'id' => 'enabled' ],
+			[ 'group_id' => 'email_failed_order',              'id' => 'recipient' ],
+			[ 'group_id' => 'email_customer_on_hold_order',    'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_processing_order', 'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_completed_order',  'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_refunded_order',   'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_new_account',      'id' => 'enabled' ],
+		];
+		$response = [];
+
+		foreach ( $items as $item ) {
+				$_response = $this->get_option( $item );
+				if ( is_wp_error( $_response ) ) {
+						$response[] = array(
+								'group_id' => $item['group_id'],
+								'id'       => $item['id'],
+								'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
+						);
+				} else {
+						$response[] = $wp_rest_server->response_to_data( $_response, '' );
+				}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Get single settings option
+	 *
+	 * @param  Object with group_id and id
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_option( $request ) {
+		$options_controller = new WC_REST_Dev_Setting_Options_Controller;
+		$response = $options_controller->get_item( $request );
+		return $response;
+	}
+
+}

--- a/wc-api-dev-class.php
+++ b/wc-api-dev-class.php
@@ -82,6 +82,7 @@ class WC_API_Dev {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-report-top-sellers-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-reports-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-settings-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-settings-email-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-setting-options-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-shipping-zones-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-dev-shipping-zone-locations-controller.php' );
@@ -124,6 +125,7 @@ class WC_API_Dev {
 			'WC_REST_Dev_Report_Sales_Controller',
 			'WC_REST_Dev_Report_Top_Sellers_Controller',
 			'WC_REST_Dev_Reports_Controller',
+			'WC_REST_Dev_Settings_Email_Controller',
 			'WC_REST_Dev_Settings_Controller',
 			'WC_REST_Dev_Setting_Options_Controller',
 			'WC_REST_Dev_Shipping_Zones_Controller',


### PR DESCRIPTION
### Information

This PR adds new settings endpoints `settings/batch_email` that allows all fetching all the settings required to implement https://github.com/Automattic/wp-calypso/issues/15040

### Testing
To test copy this custom version of wc-api-dev to your site. Comment the endpoint setting line with permissions callback and issue curl call 
` curl https://YOURSITEURL/\?rest_route\=/wc/v3/settings/batch_email`

Better testing env will be available when Calypso PR for communicating with this endpoint will be created.