### PR TITLE
API: Update schema types for backwards compatibility with 4.9

### DIFF
--- a/api/class-wc-rest-dev-coupons-controller.php
+++ b/api/class-wc-rest-dev-coupons-controller.php
@@ -28,4 +28,16 @@ class WC_REST_Dev_Coupons_Controller extends WC_REST_Coupons_Controller {
 	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Get the Coupon's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$params = parent::get_item_schema();
+
+		$params['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		return $params;
+	}
 }

--- a/api/class-wc-rest-dev-customers-controller.php
+++ b/api/class-wc-rest-dev-customers-controller.php
@@ -28,4 +28,16 @@ class WC_REST_Dev_Customers_Controller extends WC_REST_Customers_Controller {
 	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Get the Customer's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$params = parent::get_item_schema();
+
+		$params['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		return $params;
+	}
 }

--- a/api/class-wc-rest-dev-order-refunds-controller.php
+++ b/api/class-wc-rest-dev-order-refunds-controller.php
@@ -28,4 +28,23 @@ class WC_REST_Dev_Order_Refunds_Controller extends WC_REST_Order_Refunds_Control
 	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Get the Order refund's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$params = parent::get_item_schema();
+
+		$params['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['line_items']['items']['properties']['name']['type'] = 'mixed';
+		$params['properties']['line_items']['items']['properties']['product_id']['type'] = 'mixed';
+		$params['properties']['line_items']['items']['properties']['tax_class']['type'] = 'string';
+		$params['properties']['line_items']['items']['properties']['price']['type'] = 'number';
+		$params['properties']['line_items']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		return $params;
+	}
+
 }

--- a/api/class-wc-rest-dev-orders-controller.php
+++ b/api/class-wc-rest-dev-orders-controller.php
@@ -84,17 +84,25 @@ class WC_REST_Dev_Orders_Controller extends WC_REST_Orders_Controller {
 	public function get_item_schema() {
 		$params = parent::get_item_schema();
 
-		$params['properties']['line_items']['items']['properties']['tax_class'] = array(
-			'description' => __( 'Tax class of product.', 'woocommerce' ),
-			'type'        => 'string',
-			'context'     => array( 'view', 'edit' ),
-		);
-		$params['properties']['line_items']['items']['properties']['price'] = array(
-			'description' => __( 'Product price.', 'woocommerce' ),
-			'type'        => 'number',
-			'context'     => array( 'view', 'edit' ),
-			'readonly'    => true,
-		);
+		$params['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['line_items']['items']['properties']['name']['type'] = 'mixed';
+		$params['properties']['line_items']['items']['properties']['product_id']['type'] = 'mixed';
+		$params['properties']['line_items']['items']['properties']['tax_class']['type'] = 'string';
+		$params['properties']['line_items']['items']['properties']['price']['type'] = 'number';
+		$params['properties']['line_items']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['tax_lines']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['shipping_lines']['items']['properties']['method_title']['type'] = 'mixed';
+		$params['properties']['shipping_lines']['items']['properties']['method_id']['type'] = 'mixed';
+		$params['properties']['shipping_lines']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['fee_lines']['items']['properties']['name']['type'] = 'mixed';
+		$params['properties']['fee_lines']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
+
+		$params['properties']['coupon_lines']['items']['properties']['code']['type'] = 'mixed';
+		$params['properties']['coupon_lines']['items']['properties']['meta_data']['items']['properties']['value']['type'] = 'mixed';
 
 		return $params;
 	}

--- a/api/class-wc-rest-dev-product-variations-controller.php
+++ b/api/class-wc-rest-dev-product-variations-controller.php
@@ -725,7 +725,7 @@ class WC_REST_Dev_Product_Variations_Controller extends WC_REST_Product_Variatio
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/api/class-wc-rest-dev-products-controller.php
+++ b/api/class-wc-rest-dev-products-controller.php
@@ -737,7 +737,7 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),


### PR DESCRIPTION
This PR merges this change https://github.com/woocommerce/woocommerce/pull/17849 into wc-api-dev, so that all atomic sites can get the fix. This is basically the same as #71, this time we're setting the type to `mixed`, which is basically made-up and allows us to fall through the core validation + sanitization, to WC's validation (which was the pre-4.9 behavior).

Specifically this…

- Updates all instances of `meta_data.value` to `mixed`, since this value might be a serialized array (which is unserialized when passed through API, giving us an object in the response).
- Updates any instance of `'product_id', 'method_id', 'method_title', 'name', 'code'` in an order-item field (line_items, fee_lines, etc) to `mixed`, so that they can be null, as this is how they're deleted

See https://github.com/woocommerce/woocommerce/issues/17818 for more details & a simple test case.

There was chat in p1511286728000318-slack-proton about making these meta_data objects internal, so we won't be passing them around. I also suggested leaving it out of our (calypso-side) API requests, since AFAIK we're not using it anywhere.

A note about the really alarmingly long array-access: those are all defined in the parent class, so I think it's safe to assume they do exist and not check for them.

**To test:**

I believe the fix is going out in WC 3.2.5 (it already is in master), so to test this fix, make sure you're not already on the latest version.

Send a request `POST /orders/:orderId`

```js
{
  "fee_lines": [
    {
      "id": yourFeeId,
      "name": null
    }
  ]
}
```

To test the meta_data fixes, the easiest way is to trigger the request from Calypso by trying to edit an order which has a coupon applied.