### PR TITLE
Enable order refunds per-item via the API

### DIFF
--- a/api/class-wc-rest-dev-order-refunds-controller.php
+++ b/api/class-wc-rest-dev-order-refunds-controller.php
@@ -29,6 +29,65 @@ class WC_REST_Dev_Order_Refunds_Controller extends WC_REST_Order_Refunds_Control
 	protected $namespace = 'wc/v3';
 
 	/**
+	 * Prepares one object for create or update operation.
+	 *
+	 * @since  3.0.0
+	 * @param  WP_REST_Request $request Request object.
+	 * @param  bool            $creating If is creating a new object.
+	 * @return WP_Error|WC_Data The prepared item, or WP_Error object on failure.
+	 */
+	protected function prepare_object_for_database( $request, $creating = false ) {
+		$order = wc_get_order( (int) $request['order_id'] );
+
+		if ( ! $order ) {
+			return new WP_Error( 'woocommerce_rest_invalid_order_id', __( 'Invalid order ID.', 'woocommerce' ), 404 );
+		}
+
+		if ( 0 > $request['amount'] ) {
+			return new WP_Error( 'woocommerce_rest_invalid_order_refund', __( 'Refund amount must be greater than zero.', 'woocommerce' ), 400 );
+		}
+
+		// Create the refund.
+		$refund = wc_create_refund(
+			array(
+				'order_id'       => $order->get_id(),
+				'amount'         => $request['amount'],
+				'reason'         => empty( $request['reason'] ) ? null : $request['reason'],
+				'line_items'     => empty( $request['line_items'] ) ? array() : $request['line_items'],
+				'refund_payment' => is_bool( $request['api_refund'] ) ? $request['api_refund'] : true,
+				'restock_items'  => true,
+			)
+		);
+
+		if ( is_wp_error( $refund ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create_order_refund', $refund->get_error_message(), 500 );
+		}
+
+		if ( ! $refund ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce' ), 500 );
+		}
+
+		if ( ! empty( $request['meta_data'] ) && is_array( $request['meta_data'] ) ) {
+			foreach ( $request['meta_data'] as $meta ) {
+				$refund->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+			}
+			$refund->save_meta_data();
+		}
+
+		/**
+		 * Filters an object before it is inserted via the REST API.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`,
+		 * refers to the object type slug.
+		 *
+		 * @param WC_Data         $coupon   Object object.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param bool            $creating If is creating a new object.
+		 */
+		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $refund, $request, $creating );
+	}
+
+	/**
 	 * Get the Order refund's schema, conforming to JSON Schema.
 	 *
 	 * @return array

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -129,6 +129,7 @@ class WC_API_Dev_Unit_Tests_Bootstrap {
 		
 		// Added helpers
 		require_once( $this->tests_dir  . '/framework/helpers/class-wc-helper-order-note.php' );
+		require_once( $this->tests_dir  . '/framework/helpers/class-wc-helper-order-refund.php' );
 	}
 
 	/**

--- a/tests/framework/helpers/class-wc-helper-order-refund.php
+++ b/tests/framework/helpers/class-wc-helper-order-refund.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Class WC_Helper_Order_Refund.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Helper_Order_Refund {
+
+	/**
+	 * Create an order refund.
+	 *
+	 * @since   2.4
+	 *
+	 * @param int    $order_id
+	 * @param int    $customer_id
+	 *
+	 * @return WC_Order_Refund
+	 */
+	public static function create_refund( $order_id, $customer_id = 1 ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return false;
+		}
+
+		// Create the refund.
+		$refund = array(
+			'amount' => 5.0,
+			'reason' => 'Testing',
+			'order_id' => $order_id,
+		);
+		$refund_obj = wc_create_refund( $refund );
+
+		if ( ! $refund_obj || is_wp_error( $refund_obj ) ) {
+			return false;
+		}
+
+		return $refund_obj;
+	}
+	
+	/**
+	 * Create an order refund with line_items.
+	 *
+	 * @since   2.4
+	 *
+	 * @param int    $order_id
+	 * @param int    $customer_id
+	 *
+	 * @return WC_Order_Refund
+	 */
+	public static function create_refund_with_items( $order_id, $customer_id = 1 ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return false;
+		}
+		$items = $order->get_items();
+		$item_id = key( $items );
+		// Create the refund.
+		$refund = array(
+			'amount' => 5.0,
+			'reason' => 'Testing',
+			'order_id' => $order_id,
+			'line_items' => array(),
+		);
+		$refund['line_items'][ $item_id ] = array(
+			'qty' => 1,
+			'refund_total' => 5.0,
+		);
+		$refund_obj = wc_create_refund( $refund );
+
+		if ( ! $refund_obj || is_wp_error( $refund_obj ) ) {
+			return false;
+		}
+
+		return $refund_obj;
+	}
+	
+	
+	/**
+	 * Create an array of line_items based on a given order.
+	 *
+	 * @since   2.4
+	 *
+	 * @param int    $order_id
+	 * @param int    $count
+	 *
+	 * @return array
+	 */
+	public static function create_refund_line_items( $order_id, $count ) {
+		$order = wc_get_order( $order_id );
+		$items = $order->get_items();
+		$line_items = array();
+
+		// Create line items up to count, as long as there are items to use.
+		$item_id = key( $items );
+		$i = 0;
+		while ( $item_id && ( $i < $count ) ) {
+			$line_items[ $item_id ] = array(
+				'qty' => 1,
+				'refund_total' => 5.0,
+			);
+			// Next loop…
+			$item_id = key( $items );
+			$i++;
+		}
+		return $line_items;
+	}
+}

--- a/tests/unit-tests/order-refunds.php
+++ b/tests/unit-tests/order-refunds.php
@@ -151,12 +151,13 @@ class WC_Tests_API_Order_Refunds extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $data['amount'], '5.00' );
 		$this->assertEquals( $data['reason'], 'This is testing content.' );
 		$this->assertEquals( $data['refunded_by'], get_current_user_id() );
-		// $this->assertEquals( 1, count( $data['line_items'] ) );
+		$this->assertEquals( 1, count( $data['line_items'] ) );
 
 		// Verify that Note object has correct data
 		$this->assertEquals( $refund->get_amount(), '5.00' );
 		$this->assertEquals( $refund->get_reason(), 'This is testing content.' );
-		// $refund->get_items()
+		$items = $refund->get_items();
+		$this->assertEquals( 1, count( $items ) );
 
 		$refund->delete();
 	}

--- a/tests/unit-tests/order-refunds.php
+++ b/tests/unit-tests/order-refunds.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests for the order refunds REST API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.0.0
+ */
+class WC_Tests_API_Order_Refunds extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Array of refunds to track.
+	 * @var array
+	 */
+	protected $refunds = array();
+
+	/**
+	 * An order to hold these refunds.
+	 * @var int
+	 */
+	protected $order_id;
+
+	/**
+	 * Setup our test server.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_DEV_Orders_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		$order = WC_Helper_Order::create_order();
+		$this->order_id = $order->get_id();
+	}
+
+	/**
+	 * Cleanup.
+	 */
+	public function stoppit_and_tidyup() {
+		wp_delete_post( $this->order_id, true );
+		foreach ( $this->refunds as $refund ) {
+			$refund->delete();
+		}
+		$this->refunds = array();
+	}
+
+	/**
+	 * Test route registration.
+	 * @since 3.0.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v3/orders/(?P<order_id>[\d]+)/refunds', $routes );
+		$this->assertArrayHasKey( '/wc/v3/orders/(?P<order_id>[\d]+)/refunds/(?P<id>[\d]+)', $routes );
+	}
+
+	/**
+	 * Test getting all refunds for an order.
+	 * @since 3.0.0
+	 */
+	public function test_get_items() {
+		wp_set_current_user( $this->user );
+
+		// Create 2 partial order refunds.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->refunds[] = WC_Helper_Order_Refund::create_refund( $this->order_id, $this->user );
+		}
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', "/wc/v3/orders/$this->order_id/refunds" ) );
+		$refunds  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $refunds ) );
+		$this->stoppit_and_tidyup();
+	}
+
+	/**
+	 * Tests getting a single order refund.
+	 * @since 3.0.0
+	 */
+	public function test_get_item() {
+		wp_set_current_user( $this->user );		
+		$refund          = WC_Helper_Order_Refund::create_refund_with_items( $this->order_id, $this->user );
+		$this->refunds[] = $refund;
+
+		$request  = new WP_REST_Request( 'GET', "/wc/v3/orders/$this->order_id/refunds/" . $refund->get_id() );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'date_created', $data );
+		$this->assertEquals( $data['amount'], '5.00' );
+		$this->assertEquals( $data['reason'], 'Testing' );
+		$this->assertArrayHasKey( 'line_items', $data );
+		$this->assertEquals( 1, count( $data['line_items'] ) );
+
+		$this->stoppit_and_tidyup();
+	}
+
+	/**
+	 * Tests creating an order refund by a given user.
+	 * @since 3.0.0
+	 */
+	public function test_create_refund() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'POST', "/wc/v3/orders/$this->order_id/refunds" );
+		$request->set_body_params( array(
+			'amount'     => '5.0',
+			'reason'     => 'This is testing content.',
+			'api_refund' => false,
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$refund   = new WC_Order_Refund( $data['id'] );
+
+		$this->assertEquals( 201, $response->get_status() );
+		// Verify the API response has correct data
+		$this->assertArrayHasKey( 'date_created', $data );
+		$this->assertEquals( $data['amount'], '5.00' );
+		$this->assertEquals( $data['reason'], 'This is testing content.' );
+		$this->assertEquals( $data['refunded_by'], get_current_user_id() );
+
+		// Verify that Note object has correct data
+		$this->assertEquals( $refund->get_amount(), '5.00' );
+		$this->assertEquals( $refund->get_reason(), 'This is testing content.' );
+
+		$refund->delete();
+	}
+	
+	/**
+	 * Tests creating an order refund by a given user.
+	 * @since 3.0.0
+	 */
+	public function test_create_refund_with_items() {
+		wp_set_current_user( $this->user );
+		$line_items = WC_Helper_Order_Refund::create_refund_line_items( $this->order_id, 1 );
+		$request    = new WP_REST_Request( 'POST', "/wc/v3/orders/$this->order_id/refunds" );
+		$request->set_body_params( array(
+			'amount'     => '5.0',
+			'reason'     => 'This is testing content.',
+			'api_refund' => false,
+			'line_items' => $line_items,
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$refund   = new WC_Order_Refund( $data['id'] );
+
+		$this->assertEquals( 201, $response->get_status() );
+		// Verify the API response has correct data
+		$this->assertArrayHasKey( 'date_created', $data );
+		$this->assertArrayHasKey( 'line_items', $data );
+		$this->assertEquals( $data['amount'], '5.00' );
+		$this->assertEquals( $data['reason'], 'This is testing content.' );
+		$this->assertEquals( $data['refunded_by'], get_current_user_id() );
+		// $this->assertEquals( 1, count( $data['line_items'] ) );
+
+		// Verify that Note object has correct data
+		$this->assertEquals( $refund->get_amount(), '5.00' );
+		$this->assertEquals( $refund->get_reason(), 'This is testing content.' );
+		// $refund->get_items()
+
+		$refund->delete();
+	}
+}


### PR DESCRIPTION
This addresses #83 (maybe as a workaround?) – the API endpoint for refunds currently only accepts simple refunds (an amount & reason), but the function it uses, `wc_create_refund`, can take a  `line_items` property. The format for this property is not consistent with eg updating an order, but it can be used to refund & restock products.

This PR adds tests for the refunds endpoint, and enables the line_items property when creating a refund via API.

Example: `POST /wc/v3/orders/:orderId/refunds`

```
{
	"reason": "Line Item refund",
	"amount": "15.00",
	"line_items": {
		"139": {
			"qty": 1,
			"refund_total": "15.00"
		}
	}
}
```

In the above example, 139 is the ID from the order's `line_items`, of the product we want to refund (grab this with `GET /wc/v3/orders/:orderId/`). This uses `qty` for quantity, and `refund_total` should be the total refunded amount for this item. `amount` is still required for the refund to update the order total, it does not calculate the total from line_items.

Once refunded, line items are updated as expected in wp-admin:

<img width="739" alt="screen shot 2018-01-29 at 1 22 09 pm" src="https://user-images.githubusercontent.com/541093/35527082-8a4afbd0-04f7-11e8-8ab7-d4a047b4d97f.png">

**Note**: I'm not suggesting this is a great solution to the problem of refunding line_items via the API - the points raised in #83 still apply, but this will work for my purpose of allowing refunds from Calypso https://github.com/Automattic/wp-calypso/issues/15675

**To test**

- Run the tests: `phpunit tests/unit-tests/order-refunds.php`
- Try submitting a refund for an order, given the API format above