### PR TITLE
Expose title field types via payment gateway API.

### DIFF
--- a/api/class-wc-rest-dev-payment-gateways-controller.php
+++ b/api/class-wc-rest-dev-payment-gateways-controller.php
@@ -65,6 +65,43 @@ class WC_REST_Dev_Payment_Gateways_Controller extends WC_REST_Payment_Gateways_C
 	}
 
 	/**
+	 * Return settings associated with this payment gateway.
+	 *
+	 * @param WC_Payment_Gateway $gateway
+	 *
+	 * @return array
+	 */
+	public function get_settings( $gateway ) {
+		$settings = array();
+		$gateway->init_form_fields();
+		foreach ( $gateway->form_fields as $id => $field ) {
+			// Make sure we at least have a title and type
+			if ( empty( $field['title'] ) || empty( $field['type'] ) ) {
+				continue;
+			}
+			// Ignore 'enabled' and 'description' which get included elsewhere.
+			if ( in_array( $id, array( 'enabled', 'description' ) ) ) {
+				continue;
+			}
+			$data = array(
+				'id'          => $id,
+				'label'       => empty( $field['label'] ) ? $field['title'] : $field['label'],
+				'description' => empty( $field['description'] ) ? '' : $field['description'],
+				'type'        => $field['type'],
+				'value'       => empty( $gateway->settings[ $id ] ) ? '' : $gateway->settings[ $id ],
+				'default'     => empty( $field['default'] ) ? '' : $field['default'],
+				'tip'         => empty( $field['description'] ) ? '' : $field['description'],
+				'placeholder' => empty( $field['placeholder'] ) ? '' : $field['placeholder'],
+			);
+			if ( ! empty( $field['options'] ) ) {
+				$data['options'] = $field['options'];
+			}
+			$settings[ $id ] = $data;
+		}
+		return $settings;
+	}
+
+	/**
 	 * Get the payment gateway schema, conforming to JSON Schema.
 	 *
 	 * @return array


### PR DESCRIPTION
To support all Payment Methods added via extensions in Calypso, we need to have the Payment Gateways API return "title" field types which are used for grouping fields - as seen in Klarna:

<img width="499" alt="klarna-groups" src="https://user-images.githubusercontent.com/22080/35837653-3590357e-0a9c-11e8-9c81-15ad99f45e4f.png">

This PR copies over the base version `$payment_gateway_controller->get_settings()` and modifies it to not omit `'title' === $field['type']` 