### PR TITLE
Add currency details to countries in locations endpoint

### DIFF
--- a/api/class-wc-rest-dev-data-continents-controller.php
+++ b/api/class-wc-rest-dev-data-continents-controller.php
@@ -126,6 +126,22 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 					}
 				}
 				$country['states'] = $local_states;
+
+				// Allow only desired keys (e.g. filter out tax rates)
+				$allowed = array(
+					'code',
+					'currency_code',
+					'currency_pos',
+					'decimal_sep',
+					'dimension_unit',
+					'name',
+					'num_decimals',
+					'states',
+					'thousand_sep',
+					'weight_unit',
+				);
+				$country = array_intersect_key( $country, array_flip( $allowed ) );
+
 				$local_countries[] = $country;
 			}
 		}
@@ -255,9 +271,39 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
+							'currency_code' => array(
+								'type'        => 'string',
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_pos' => array(
+								'type'        => 'string',
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'decimal_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'dimension_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
 							'name' => array(
 								'type'        => 'string',
 								'description' => __( 'Full name of country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'num_decimals' => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
@@ -285,6 +331,18 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 										),
 									),
 								),
+							),
+							'thousand_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'weight_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
 							),
 						),
 					),

--- a/api/class-wc-rest-dev-data-continents-controller.php
+++ b/api/class-wc-rest-dev-data-continents-controller.php
@@ -95,34 +95,26 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 		$local_countries = array();
 		foreach ( $continent_list['countries'] as $country_code ) {
 			if ( isset( $countries[ $country_code ] ) ) {
-				$locale_data = array();
-				if ( array_key_exists( $country_code, $locale_info ) ) {
-					$locale_data = $locale_info[ $country_code ];
-				}
-
-				// Defensive programming against unexpected changes in locale-info.php
-				$locale_data = wp_parse_args( $locale_data, array(
-					'currency_code'  => 'USD',
-					'currency_pos'   => 'left',
-					'decimal_sep'    => '.',
-					'dimension_unit' => 'in',
-					'num_decimals'   => 2,
-					'thousand_sep'   => ',',
-					'weight_unit'    => 'lbs',
-				) );
-
-
 				$country = array(
 					'code'           => $country_code,
-					'currency_code'  => $locale_data[ 'currency_code' ],
-					'currency_pos'   => $locale_data[ 'currency_pos' ],
-					'decimal_sep'    => $locale_data[ 'decimal_sep' ],
-					'dimension_unit' => $locale_data[ 'dimension_unit' ],
 					'name'           => $countries[ $country_code ],
-					'num_decimals'   => $locale_data[ 'num_decimals' ],
-					'thousand_sep'   => $locale_data[ 'thousand_sep' ],
-					'weight_unit'    => $locale_data[ 'weight_unit' ],
 				);
+
+				// If we have detailed locale information include that in the response
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					// Defensive programming against unexpected changes in locale-info.php
+					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
+						'currency_code'  => 'USD',
+						'currency_pos'   => 'left',
+						'decimal_sep'    => '.',
+						'dimension_unit' => 'in',
+						'num_decimals'   => 2,
+						'thousand_sep'   => ',',
+						'weight_unit'    => 'lbs',
+					) );
+
+					$country = array_merge( $country, $country_data );
+				}
 
 				$local_states = array();
 				if ( isset( $states[ $country_code ] ) ) {

--- a/api/class-wc-rest-dev-data-continents-controller.php
+++ b/api/class-wc-rest-dev-data-continents-controller.php
@@ -96,8 +96,8 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 		foreach ( $continent_list['countries'] as $country_code ) {
 			if ( isset( $countries[ $country_code ] ) ) {
 				$country = array(
-					'code'           => $country_code,
-					'name'           => $countries[ $country_code ],
+					'code' => $country_code,
+					'name' => $countries[ $country_code ],
 				);
 
 				// If we have detailed locale information include that in the response

--- a/api/class-wc-rest-dev-data-continents-controller.php
+++ b/api/class-wc-rest-dev-data-continents-controller.php
@@ -75,10 +75,11 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 * @return array|mixed Response data, ready for insertion into collection data.
 	 */
 	public function get_continent( $continent_code = false, $request ) {
-		$continents = WC()->countries->get_continents();
-		$countries  = WC()->countries->get_countries();
-		$states     = WC()->countries->get_states();
-		$data       = array();
+		$continents  = WC()->countries->get_continents();
+		$countries   = WC()->countries->get_countries();
+		$states      = WC()->countries->get_states();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$data        = array();
 
 		if ( ! array_key_exists( $continent_code, $continents ) ) {
 			return false;
@@ -94,9 +95,33 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 		$local_countries = array();
 		foreach ( $continent_list['countries'] as $country_code ) {
 			if ( isset( $countries[ $country_code ] ) ) {
+				$locale_data = array();
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					$locale_data = $locale_info[ $country_code ];
+				}
+
+				// Defensive programming against unexpected changes in locale-info.php
+				$locale_data = wp_parse_args( $locale_data, array(
+					'currency_code'  => 'USD',
+					'currency_pos'   => 'left',
+					'decimal_sep'    => '.',
+					'dimension_unit' => 'in',
+					'num_decimals'   => 2,
+					'thousand_sep'   => ',',
+					'weight_unit'    => 'lbs',
+				) );
+
+
 				$country = array(
-					'code' => $country_code,
-					'name' => $countries[ $country_code ],
+					'code'           => $country_code,
+					'currency_code'  => $locale_data[ 'currency_code' ],
+					'currency_pos'   => $locale_data[ 'currency_pos' ],
+					'decimal_sep'    => $locale_data[ 'decimal_sep' ],
+					'dimension_unit' => $locale_data[ 'dimension_unit' ],
+					'name'           => $countries[ $country_code ],
+					'num_decimals'   => $locale_data[ 'num_decimals' ],
+					'thousand_sep'   => $locale_data[ 'thousand_sep' ],
+					'weight_unit'    => $locale_data[ 'weight_unit' ],
 				);
 
 				$local_states = array();

--- a/tests/unit-tests/data.php
+++ b/tests/unit-tests/data.php
@@ -62,6 +62,33 @@ class Data_API extends WC_REST_Unit_Test_Case {
 		$this->assertNotEmpty( $locations[0]['name'] );
 		$this->assertNotEmpty( $locations[0]['countries'] );
 		$this->assertNotEmpty( $locations[0]['_links'] );
+
+		// Make sure North America is in the response
+		$NA_index = -1;
+		foreach( $locations as $index => $continent ) {
+			if ( "NA" === $continent['code'] ) {
+				$NA_index = $index;
+			}
+		}
+		$this->assertGreaterThan( -1, $NA_index );
+
+		// Make sure the United States is in the North America part of the response
+		$US_index = -1;
+		foreach( $locations[ $NA_index ]['countries'] as $index => $country ) {
+			if ( "US" === $country['code'] ) {
+				$US_index = $index;
+			}
+		}
+		$this->assertGreaterThan( -1, $US_index );
+
+		// Lastly, assertNotEmpty US has currency, dimensions, etc.
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['currency_code'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['currency_pos'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['thousand_sep'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['decimal_sep'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['num_decimals'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['dimension_unit'] );
+		$this->assertNotEmpty( $locations[ $NA_index ]['countries'][ $US_index ]['weight_unit'] );
 	}
 
 	/**
@@ -111,13 +138,6 @@ class Data_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'US', $locations['code'] );
 		$this->assertNotEmpty( $locations['name'] );
 		$this->assertCount( 54, $locations['states'] );
-		$this->assertNotEmpty( $locations['currency_code'] );
-		$this->assertNotEmpty( $locations['currency_pos'] );
-		$this->assertNotEmpty( $locations['thousand_sep'] );
-		$this->assertNotEmpty( $locations['decimal_sep'] );
-		$this->assertNotEmpty( $locations['num_decimals'] );
-		$this->assertNotEmpty( $locations['dimension_unit'] );
-		$this->assertNotEmpty( $locations['weight_unit'] );
 		$links = $response->get_links();
 		$this->assertCount( 2, $links );
 	}

--- a/tests/unit-tests/data.php
+++ b/tests/unit-tests/data.php
@@ -93,6 +93,13 @@ class Data_API extends WC_REST_Unit_Test_Case {
 		$this->assertGreaterThan( 1, count( $locations ) );
 		$this->assertNotEmpty( $locations[0]['code'] );
 		$this->assertNotEmpty( $locations[0]['name'] );
+		$this->assertNotEmpty( $locations[0]['currency_code'] );
+		$this->assertNotEmpty( $locations[0]['currency_pos'] );
+		$this->assertNotEmpty( $locations[0]['thousand_sep'] );
+		$this->assertNotEmpty( $locations[0]['decimal_sep'] );
+		$this->assertNotEmpty( $locations[0]['num_decimals'] );
+		$this->assertNotEmpty( $locations[0]['dimension_unit'] );
+		$this->assertNotEmpty( $locations[0]['weight_unit'] );
 		$this->assertArrayHasKey( 'states', $locations[0] );
 		$this->assertNotEmpty( $locations[0]['_links'] );
 	}

--- a/tests/unit-tests/data.php
+++ b/tests/unit-tests/data.php
@@ -93,19 +93,13 @@ class Data_API extends WC_REST_Unit_Test_Case {
 		$this->assertGreaterThan( 1, count( $locations ) );
 		$this->assertNotEmpty( $locations[0]['code'] );
 		$this->assertNotEmpty( $locations[0]['name'] );
-		$this->assertNotEmpty( $locations[0]['currency_code'] );
-		$this->assertNotEmpty( $locations[0]['currency_pos'] );
-		$this->assertNotEmpty( $locations[0]['thousand_sep'] );
-		$this->assertNotEmpty( $locations[0]['decimal_sep'] );
-		$this->assertNotEmpty( $locations[0]['num_decimals'] );
-		$this->assertNotEmpty( $locations[0]['dimension_unit'] );
-		$this->assertNotEmpty( $locations[0]['weight_unit'] );
 		$this->assertArrayHasKey( 'states', $locations[0] );
 		$this->assertNotEmpty( $locations[0]['_links'] );
 	}
 
 	/**
 	 * Test getting locations restricted to one country.
+	 * Use a country (US) that includes locale info
 	 * @since 3.1.0
 	 */
 	public function test_get_locations_from_country() {
@@ -117,6 +111,13 @@ class Data_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'US', $locations['code'] );
 		$this->assertNotEmpty( $locations['name'] );
 		$this->assertCount( 54, $locations['states'] );
+		$this->assertNotEmpty( $locations['currency_code'] );
+		$this->assertNotEmpty( $locations['currency_pos'] );
+		$this->assertNotEmpty( $locations['thousand_sep'] );
+		$this->assertNotEmpty( $locations['decimal_sep'] );
+		$this->assertNotEmpty( $locations['num_decimals'] );
+		$this->assertNotEmpty( $locations['dimension_unit'] );
+		$this->assertNotEmpty( $locations['weight_unit'] );
 		$links = $response->get_links();
 		$this->assertCount( 2, $links );
 	}


### PR DESCRIPTION
Fixes #88 

To test:
- Run the `phpunit` tests. New tests were added. Note that you can ignore the failures in the product variations tests if they occur - #90 
- Next, I recommend using Postman to send authenticated queries to `GET http://your_host_here/wp-json/wc/v3/data/continents`
- I like using the https://github.com/WP-API/Basic-Auth plugin to allow me to pass a base64_encode-d username:password from Postman to my test site
- Out of the 250 countries returned by this endpoint, 23 should have additional information added to them about their currency display and dimensions, e.g.: for the Netherlands:

```
            {
                "code": "NL",
                "name": "Netherlands",
                "currency_code": "EUR",
                "currency_pos": "left",
                "decimal_sep": ".",
                "dimension_unit": "cm",
                "num_decimals": 2,
                "thousand_sep": ",",
                "weight_unit": "kg",
                "states": []
            },
```