### PR TITLE
Make product orderby features available to the API

### DIFF
--- a/api/class-wc-rest-dev-products-controller.php
+++ b/api/class-wc-rest-dev-products-controller.php
@@ -74,6 +74,29 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 	}
 
 	/**
+	 * Make extra product orderby features supported by WooCommerce available to the WC API. 
+	 * This includes 'price', 'popularity', and 'rating'.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args = parent::prepare_objects_query( $request );
+
+		$orderby = $request->get_param( 'orderby' );
+		$order = $request->get_param( 'order' );
+
+		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
+		$args['orderby'] = $ordering_args['orderby'];
+		$args['order']   = $ordering_args['order'];
+		if ( $ordering_args['meta_key'] ) {
+			$args['meta_key'] = $ordering_args['meta_key'];
+		}
+
+		return $args;
+	}
+
+	/**
 	 * Set product images.
 	 *
 	 * @throws WC_REST_Exception REST API exceptions.
@@ -132,6 +155,17 @@ class WC_REST_Dev_Products_Controller extends WC_REST_Products_Controller {
 		}
 
 		return $product;
+	}
+
+	/**
+	 * Add new options for 'orderby' to the collection params.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating' ) );
+		return $params;
 	}
 
 	/**

--- a/tests/unit-tests/products.php
+++ b/tests/unit-tests/products.php
@@ -96,8 +96,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'Product 2', $products[0]['name'] );
-
-
 	}
 
 	/**

--- a/tests/unit-tests/products.php
+++ b/tests/unit-tests/products.php
@@ -54,6 +54,109 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Create three assorted products suitable for testing new orderby features in API queries.
+	 *
+	 * @since 3.4.0
+	 */
+	protected function create_dummy_orderby_products() {
+		// Create three products with different prices and sales.
+		$product1 = new WC_Product();
+		$product1->set_name( 'Product 1' );
+		$product1->set_regular_price( '5.00' );
+		$product1->save();
+		update_post_meta( $product1->get_id(), 'total_sales', 5 );
+
+		$product2 = new WC_Product();
+		$product2->set_name( 'Product 2' );
+		$product2->set_regular_price( '10.00' );
+		$product2->save();
+		update_post_meta( $product2->get_id(), 'total_sales', 8 );
+
+		$product3 = new WC_Product();
+		$product3->set_name( 'Product 3' );
+		$product3->set_regular_price( '1.00' );
+		$product3->save();
+		update_post_meta( $product3->get_id(), 'total_sales', 2 );
+	}
+
+	/**
+	 * Test orderby price descending.
+	 *
+	 * @since 3.4.0
+	 */
+	public function test_get_products_orderby_price_desc() {
+		wp_set_current_user( $this->user );
+		$this->create_dummy_orderby_products();
+
+		// Order by price descending.
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( array( 'orderby' => 'price', 'order' => 'desc' ) );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Product 2', $products[0]['name'] );
+
+
+	}
+
+	/**
+	 * Test orderby price ascending.
+	 *
+	 * @since 3.4.0
+	 */
+	public function test_get_products_orderby_price_asc() {
+		wp_set_current_user( $this->user );
+		$this->create_dummy_orderby_products();
+
+		// Order by price ascending.
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( array( 'orderby' => 'price', 'order' => 'asc' ) );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Product 3', $products[0]['name'] );
+	}
+
+	/**
+	 * Test orderby sales.
+	 *
+	 * @since 3.4.0
+	 */
+	public function test_get_products_orderby_sales() {
+		wp_set_current_user( $this->user );
+		$this->create_dummy_orderby_products();
+
+		// Order by sales.
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( array( 'orderby' => 'popularity' ) );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Product 2', $products[0]['name'] );
+	}
+
+	/**
+	 * Test orderby rating. This just checks it's a valid, registered option and is further tested in class-wc-tests-wc-query.php.
+	 *
+	 * @since 3.4.0
+	 */
+	public function test_get_products_orderby_rating() {
+		wp_set_current_user( $this->user );
+		$this->create_dummy_orderby_products();
+
+		// Order by sales.
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( array( 'orderby' => 'rating' ) );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
 	 * Test getting products without permission.
 	 *
 	 * @since 3.0.0


### PR DESCRIPTION
Closes #98 

This adds support for orderby 'price', 'popularity', and 'rating' to the WC API. These fields are supported in the shortcode and catalog on the frontend, but were not available in the API until now. They are needed [for the Gutenberg products block](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/67#issue-175336121).

To test: Run the unit tests or make an API call using the new orderby features.